### PR TITLE
Add gstreamer integration and a vision Action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,16 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-expr"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40ccee03b5175c18cde8f37e7d2a33bcef6f8ec8f7cc0d81090d1bb380949c9"
-dependencies = [
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,117 +518,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
-name = "gio-sys"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
- "winapi",
-]
-
-[[package]]
-name = "glib"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19"
-dependencies = [
- "bitflags 2.4.0",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-task",
- "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
- "libc",
- "memchr",
- "once_cell",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "glib-macros"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8da903822b136d42360518653fcf154455defc437d3e7a81475bf9a95ff1e47"
-dependencies = [
- "heck",
- "proc-macro-crate",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "glib-sys"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
-dependencies = [
- "libc",
- "system-deps",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gobject-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
-dependencies = [
- "glib-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gstreamer"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b369a1eb2f7db49920d3d590bd988c5fb56dbf2347e1efb60307fe953546ee5d"
-dependencies = [
- "cfg-if",
- "futures-channel",
- "futures-core",
- "futures-util",
- "glib",
- "gstreamer-sys",
- "itertools",
- "libc",
- "muldiv",
- "num-integer",
- "num-rational",
- "option-operations",
- "paste",
- "pretty-hex",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gstreamer-sys"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86bf9de67a6ab7af67ac11588f4939e984a936030437219f269fe969d79ad8c"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
-]
 
 [[package]]
 name = "h2"
@@ -670,12 +553,6 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -949,12 +826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "muldiv"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
-
-[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,27 +855,6 @@ dependencies = [
  "memoffset",
  "pin-utils",
  "static_assertions",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -1119,15 +969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-operations"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
-dependencies = [
- "paste",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,12 +1001,6 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
@@ -1202,46 +1037,6 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "pretty-hex"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.14",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1565,7 +1360,6 @@ dependencies = [
  "derive-getters",
  "flate2",
  "futures",
- "gstreamer",
  "itertools",
  "num-traits",
  "opencv",
@@ -1574,7 +1368,7 @@ dependencies = [
  "tar",
  "tokio",
  "tokio-serial",
- "toml 0.8.1",
+ "toml",
  "zip-extract",
 ]
 
@@ -1601,19 +1395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c2de8a4d8f4b823d634affc9cd2a74ec98c53a756f317e529a48046cbf71f3"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml 0.7.6",
- "version-compare",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,12 +1404,6 @@ dependencies = [
  "libc",
  "xattr",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
@@ -1765,18 +1540,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.14",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc1433177506450fe920e46a4f9812d0c211f5dd556da10e731a0a3dfa151f0"
@@ -1784,7 +1547,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1794,19 +1557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
-dependencies = [
- "indexmap 2.0.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -1897,12 +1647,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-compare"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,9 +529,9 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gio-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccf87c30a12c469b6d958950f6a9c09f2be20b7773f7e70d20b867fdf2628c3"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -542,11 +542,11 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.10"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fad45ba8d4d2cea612b432717e834f48031cd8853c8aaf43b2c79fec8d144b"
+checksum = "1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -565,24 +565,23 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.17.10"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca5c79337338391f1ab8058d6698125034ce8ef31b72a442437fa6c8580de26"
+checksum = "f8da903822b136d42360518653fcf154455defc437d3e7a81475bf9a95ff1e47"
 dependencies = [
- "anyhow",
  "heck",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80aa6ea7bba0baac79222204aa786a6293078c210abe69ef1336911d4bdc4f0"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
  "system-deps",
@@ -596,9 +595,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34c3317740a6358ec04572c1bcfd3ac0b5b6529275fae255b237b314bb8062"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
@@ -607,22 +606,21 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.20.7"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a4150420d4aa1caf6fa15f0dba7a5007d4116380633bd1253acce206098fc9"
+checksum = "b369a1eb2f7db49920d3d590bd988c5fb56dbf2347e1efb60307fe953546ee5d"
 dependencies = [
- "bitflags 1.3.2",
  "cfg-if",
  "futures-channel",
  "futures-core",
  "futures-util",
  "glib",
  "gstreamer-sys",
+ "itertools",
  "libc",
  "muldiv",
  "num-integer",
  "num-rational",
- "once_cell",
  "option-operations",
  "paste",
  "pretty-hex",
@@ -632,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56fe047adef7d47dbafa8bc1340fddb53c325e16574763063702fc94b5786d2"
+checksum = "f86bf9de67a6ab7af67ac11588f4939e984a936030437219f269fe969d79ad8c"
 dependencies = [
  "glib-sys",
  "gobject-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ logging = []
 opencv = "0.84.4" # Vision processing
 tokio-serial = "5.4.1" # Async serial comms
 tokio = { version = "1.29.1", features = ["full"] } # Async runtime
-gstreamer = "0.21.1" # Camera streaming
 anyhow = "1.0.72" # Error handling
 itertools = "0.11.0" # Enhance iterators
 num-traits = "0.2.16" # Numeric generics

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ logging = []
 opencv = "0.84.4" # Vision processing
 tokio-serial = "5.4.1" # Async serial comms
 tokio = { version = "1.29.1", features = ["full"] } # Async runtime
-gstreamer = "0.20.7" # Camera streaming
+gstreamer = "0.21.1" # Camera streaming
 anyhow = "1.0.72" # Error handling
 itertools = "0.11.0" # Enhance iterators
 num-traits = "0.2.16" # Numeric generics

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ itertools = "0.11.0" # Enhance iterators
 num-traits = "0.2.16" # Numeric generics
 derive-getters = "0.3.0" # Getter macro
 async-trait = "0.1.73" # Async fns in trait definitions
-futures = "0.3.28" # Futures utilities
+futures = { version = "0.3.28", default-features = false, features = ["std"] }# Futures utilities
 toml = "0.8.1" # Configuration file
 serde = { version = "1.0.188", features = ["derive"] } # Config serial handling
 bytes = "1.5.0" # Byte buffering

--- a/src/comms/control_board/mod.rs
+++ b/src/comms/control_board/mod.rs
@@ -41,7 +41,7 @@ impl<T: 'static + AsyncWriteExt + Unpin + Send> ControlBoard<T> {
         #[allow(clippy::approx_constant)]
         const DOF_SPEEDS: [f32; 6] = [0.7071, 0.7071, 1.0, 0.4413, 1.0, 0.8139];
 
-        let msg_id = msg_id.unwrap_or(MessageId::default());
+        let msg_id = msg_id.unwrap_or_default();
         let responses = ResponseMap::new(comm_in).await;
         let this = Self {
             inner: AUVControlBoard::new(Mutex::from(comm_out).into(), responses, msg_id).into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod comms;
 pub mod missions;
+pub mod video_source;
 pub mod vision;

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -8,7 +8,7 @@ use super::{
 ///
 /// Runs two nested actions in order: Waiting for arm and descending in
 /// parallel, followed by waiting for arm and descending concurrently.
-fn initial_descent<T: Send + Sync>(context: &T) -> impl Action + '_ {
+pub fn initial_descent<T: Send + Sync>(context: &T) -> impl Action + '_ {
     ActionSequence::<T, T, _, _>::new(
         ActionParallel::<T, T, _, _>::new(WaitArm::new(context), Descend::new(context, -0.5)),
         ActionConcurrent::<T, T, _, _>::new(WaitArm::new(context), Descend::new(context, -1.0)),

--- a/src/missions/mod.rs
+++ b/src/missions/mod.rs
@@ -3,3 +3,4 @@ pub mod action_context;
 pub mod basic;
 pub mod meb;
 pub mod movement;
+pub mod vision;

--- a/src/missions/vision.rs
+++ b/src/missions/vision.rs
@@ -7,14 +7,17 @@ use anyhow::Result;
 use async_trait::async_trait;
 use num_traits::Num;
 
+/// Runs a vision routine to obtain object position
+///
+/// The relative position is normalized to [-1, 1] on both axes
 #[derive(Debug)]
-pub struct ModelCenterOffset<T, U, V> {
+pub struct VisionNormOffset<T, U, V> {
     context: T,
     model: U,
     _num: PhantomData<V>,
 }
 
-impl<T, U, V> ModelCenterOffset<T, U, V> {
+impl<T, U, V> VisionNormOffset<T, U, V> {
     pub const fn new(context: T, model: U) -> Self {
         Self {
             context,
@@ -24,11 +27,11 @@ impl<T, U, V> ModelCenterOffset<T, U, V> {
     }
 }
 
-impl<T, U, V> Action for ModelCenterOffset<T, U, V> {}
+impl<T, U, V> Action for VisionNormOffset<T, U, V> {}
 
 #[async_trait]
 impl<T: MatSource, V: Num + From<usize> + Send + Sync, U: VisualDetector<V> + Send + Sync>
-    ActionExec<Result<Offset2D<V>>> for ModelCenterOffset<T, U, V>
+    ActionExec<Result<Offset2D<V>>> for VisionNormOffset<T, U, V>
 where
     U::Position: RelPos<Number = V>,
 {
@@ -37,7 +40,8 @@ where
 
         let positions: Vec<_> = detections
             .iter()
-            .map(|detect| detect.position().offset())
+            .map(|detect| self.model.normalize(detect.position()))
+            .map(|detect| detect.offset())
             .collect();
 
         let positions_len = positions.len();

--- a/src/missions/vision.rs
+++ b/src/missions/vision.rs
@@ -1,0 +1,47 @@
+use std::marker::PhantomData;
+
+use super::action::{Action, ActionExec};
+use crate::video_source::MatSource;
+use crate::vision::{Offset2D, RelPos, VisualDetector};
+use anyhow::Result;
+use async_trait::async_trait;
+use num_traits::Num;
+
+#[derive(Debug)]
+pub struct ModelCenterOffset<T, U, V> {
+    context: T,
+    model: U,
+    _num: PhantomData<V>,
+}
+
+impl<T, U, V> ModelCenterOffset<T, U, V> {
+    pub const fn new(context: T, model: U) -> Self {
+        Self {
+            context,
+            model,
+            _num: PhantomData,
+        }
+    }
+}
+
+impl<T, U, V> Action for ModelCenterOffset<T, U, V> {}
+
+#[async_trait]
+impl<T: MatSource, V: Num + From<usize> + Send + Sync, U: VisualDetector<V> + Send + Sync>
+    ActionExec<Result<Offset2D<V>>> for ModelCenterOffset<T, U, V>
+where
+    U::Position: RelPos<Number = V>,
+{
+    async fn execute(mut self) -> Result<Offset2D<V>> {
+        let detections = self.model.detect_unique(&self.context.get_mat().await)?;
+
+        let positions: Vec<_> = detections
+            .iter()
+            .map(|detect| detect.position().offset())
+            .collect();
+
+        let positions_len = positions.len();
+
+        Ok(positions.into_iter().sum::<Offset2D<V>>() / positions_len)
+    }
+}

--- a/src/video_source/appsink.rs
+++ b/src/video_source/appsink.rs
@@ -1,0 +1,124 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use opencv::prelude::Mat;
+use opencv::videoio::VideoCapture;
+use opencv::videoio::VideoCaptureAPIs;
+use opencv::videoio::VideoCaptureTrait;
+use std::sync::Arc;
+use std::thread::spawn;
+use std::{fs::create_dir, path::Path};
+use tokio::sync::Mutex;
+
+use super::MatSource;
+
+#[derive(Debug)]
+pub struct Camera {
+    frame: Arc<Mutex<Option<Mat>>>,
+}
+
+impl Camera {
+    pub fn new(
+        camera_path: &str,
+        camera_name: &str,
+        filesink_dir: &Path,
+        camera_dimensions: (u32, u32),
+        rtsp: bool,
+    ) -> Result<Self> {
+        gstreamer::init()?; // Unclear if this is necessary
+        if !filesink_dir.is_dir() {
+            create_dir(filesink_dir)?
+        }
+
+        let rtsp_string = "h264. ! queue ! h264parse config_interval=-1 ! video/x-h264,stream-format=byte-stream,alignment=au ! rtspclientsink location=rtsp://127.0.0.1:8554/".to_string()
+                        + camera_name + " ";
+
+        let capture_string =
+            pipeline_head(camera_path, camera_dimensions.0, camera_dimensions.1, 30)
+                + " ! jpegdec ! tee name=raw "
+                + "raw. ! queue  ! videoconvert ! appsink "
+                + "raw. ! queue  ! videoconvert ! "
+                + &h264_enc_pipeline(2048000)
+                + " ! tee name=h264 "
+                + if rtsp { &rtsp_string } else { "" }
+                + "h264. ! queue ! mpegtsmux ! filesink location=\""
+                + filesink_dir
+                    .to_str()
+                    .ok_or(anyhow!("filesink_dir is not a string"))?
+                + "/"
+                + camera_name
+                + "\" ";
+
+        #[cfg(feature = "logging")]
+        println!("Capture string: {capture_string}");
+        let mut capture =
+            VideoCapture::from_file(&capture_string, VideoCaptureAPIs::CAP_GSTREAMER as i32)?;
+
+        let frame: Arc<Mutex<Option<Mat>>> = Arc::default();
+        let frame_copy = frame.clone();
+
+        spawn(move || loop {
+            let mut mat = Mat::default();
+            if capture.read(&mut mat).unwrap() {
+                *frame_copy.blocking_lock() = Some(mat)
+            }
+        });
+
+        Ok(Self { frame })
+    }
+
+    pub fn jetson_new(camera_path: &str, camera_name: &str, filesink_dir: &Path) -> Result<Self> {
+        Camera::new(camera_path, camera_name, filesink_dir, (800, 600), true)
+    }
+}
+
+#[async_trait]
+impl MatSource for Camera {
+    async fn get_mat(&self) -> Mat {
+        loop {
+            if let Some(mat) = self.frame.lock().await.take() {
+                return mat;
+            }
+        }
+    }
+}
+
+fn pipeline_head(device_name: &str, width: u32, height: u32, framerate: u32) -> String {
+    #[cfg(target_os = "windows")]
+    return format!("mfvideosrc device-index={device_name} ! image/jpeg, width={width}, height={height}, framerate={framerate}/1");
+
+    #[cfg(not(target_os = "windows"))]
+    return format!("v4l2src device={device_name} ! image/jpeg, width={width}, height={height}, framerate={framerate}/1");
+}
+
+fn h264_enc_pipeline(bitrate: u32) -> String {
+    if Path::new("/etc/nv_tegra_release").exists() {
+        format!(
+            "omxh264enc bitrate={bitrate} control-rate=variable ! video/x-h264,profile=baseline"
+        )
+    } else {
+        format!("x264enc tune=zerolatency speed-preset=ultrafast bitrate={bitrate} ! video/x-h264,profile=baseline")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[ignore = "requires an attached camera on a test system"]
+    #[tokio::test]
+    async fn single_camera() {
+        // 640x360
+        let output = Camera::new(
+            "/dev/video0",
+            "cam0",
+            Path::new("/tmp/camera_test"),
+            // Camera dependent parameter
+            (640, 360),
+            false,
+        )
+        .unwrap()
+        .get_mat()
+        .await;
+        println!("{:?}", output);
+    }
+}

--- a/src/video_source/appsink.rs
+++ b/src/video_source/appsink.rs
@@ -24,7 +24,6 @@ impl Camera {
         camera_dimensions: (u32, u32),
         rtsp: bool,
     ) -> Result<Self> {
-        gstreamer::init()?; // Unclear if this is necessary
         if !filesink_dir.is_dir() {
             create_dir(filesink_dir)?
         }

--- a/src/video_source/mod.rs
+++ b/src/video_source/mod.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+use opencv::prelude::Mat;
+
+pub mod appsink;
+
+#[async_trait]
+trait MatSource {
+    async fn get_mat(&self) -> Mat;
+}

--- a/src/video_source/mod.rs
+++ b/src/video_source/mod.rs
@@ -1,9 +1,31 @@
 use async_trait::async_trait;
 use opencv::prelude::Mat;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 pub mod appsink;
 
 #[async_trait]
 trait MatSource {
     async fn get_mat(&self) -> Mat;
+}
+
+#[derive(Debug)]
+pub struct SingleFrameSource {
+    inner: Arc<Mutex<Mat>>,
+}
+
+impl SingleFrameSource {
+    pub fn new(frame: Mat) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(frame)),
+        }
+    }
+}
+
+#[async_trait]
+impl MatSource for SingleFrameSource {
+    async fn get_mat(&self) -> Mat {
+        self.inner.lock().unwrap().clone()
+    }
 }

--- a/src/video_source/mod.rs
+++ b/src/video_source/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 pub mod appsink;
 
 #[async_trait]
-trait MatSource {
+pub trait MatSource: Send + Sync {
     async fn get_mat(&self) -> Mat;
 }
 

--- a/src/vision/buoy.rs
+++ b/src/vision/buoy.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use opencv::prelude::Mat;
+use opencv::{core::Size, prelude::Mat};
 
 use crate::load_onnx;
 
@@ -91,6 +91,10 @@ impl YoloProcessor for Buoy<OnnxModel> {
 
     fn detect_yolo_v5(&mut self, image: &Mat) -> Result<Vec<YoloDetection>> {
         self.model.detect_yolo_v5(image, self.threshold)
+    }
+
+    fn model_size(&self) -> Size {
+        self.model.size()
     }
 }
 

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -10,6 +10,7 @@ use opencv::{
 use std::{
     fmt::Debug,
     hash::Hash,
+    iter::Sum,
     ops::{Add, Deref, Div},
 };
 
@@ -56,6 +57,12 @@ impl<T: Num> Add for Offset2D<T> {
             x: self.x + rhs.x,
             y: self.y + rhs.y,
         }
+    }
+}
+
+impl<T: Num> Sum for Offset2D<T> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.reduce(|acc, cur| acc + cur).unwrap()
     }
 }
 

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -140,7 +140,7 @@ where
 
 pub trait VisualDetector<T: Num>: Debug {
     type ClassEnum: PartialEq + Eq + Hash + Clone;
-    type Position: RelPos + Clone;
+    type Position: RelPos<Number = f64> + Clone;
 
     fn detect(
         &mut self,
@@ -165,6 +165,9 @@ pub trait VisualDetector<T: Num>: Debug {
             .filter(|result| result.class == target)
             .collect())
     }
+
+    /// Adjusts position to [-1, 1] on both axes
+    fn normalize(&mut self, pos: &Self::Position) -> Self::Position;
 }
 
 #[derive(Debug, Clone, Getters)]

--- a/src/vision/nn_cv2.rs
+++ b/src/vision/nn_cv2.rs
@@ -57,6 +57,7 @@ where
 
 pub trait VisionModel: Debug {
     fn detect_yolo_v5(&mut self, image: &Mat, threshold: f64) -> Result<Vec<YoloDetection>>;
+    fn size(&self) -> Size;
 }
 
 /* -------------------------------------------------- */
@@ -203,6 +204,10 @@ impl VisionModel for OnnxModel {
         self.net.forward(&mut result, &result_names)?;
 
         self.process_net(result, threshold)
+    }
+
+    fn size(&self) -> Size {
+        self.model_size
     }
 }
 

--- a/src/vision/path.rs
+++ b/src/vision/path.rs
@@ -192,6 +192,18 @@ impl VisualDetector<i32> for Path {
             })
             .collect()
     }
+
+    fn normalize(&mut self, pos: &Self::Position) -> Self::Position {
+        let img_size = self.image.size().unwrap();
+        Self::Position::new(
+            ((*pos.x() / (img_size.width as f64)) - 0.5) * 2.0,
+            ((*pos.y() / (img_size.height as f64)) - 0.5) * 2.0,
+            *pos.angle(),
+            *pos.width() / (img_size.width as f64),
+            *pos.length() / (img_size.height as f64),
+            *pos.length_2() / (img_size.height as f64),
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds integration with gstreamer (using OpenCV, the gstreamer crate was removed). Also adds normalizing vision output, and provides an Action that gives the center of any vision approach's detection (normalized to [-1, 1]).