### PR TITLE
rustix: 0.38.13 -> 0.38.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [


### PR DESCRIPTION
[rustix's `rustix::fs::Dir` iterator with the `linux_raw` backend can cause memory explosion #1](https://github.com/ncsurobotics/SW8S-Rust/security/dependabot/1)