### PR TITLE
Graphing Actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1050,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,10 +1074,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1370,6 +1411,7 @@ dependencies = [
  "tokio",
  "tokio-serial",
  "toml",
+ "uuid",
  "zip-extract",
 ]
 
@@ -1662,6 +1704,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+dependencies = [
+ "getrandom",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dot-generator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aaac7ada45f71873ebce336491d1c1bc4a7c8042c7cea978168ad59e805b871"
+dependencies = [
+ "dot-structures",
+]
+
+[[package]]
+name = "dot-structures"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +550,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "graphviz-rust"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27dafd1ac303e0dfb347a3861d9ac440859bab26ec2f534bbceb262ea492a1e0"
+dependencies = [
+ "dot-generator",
+ "dot-structures",
+ "into-attr",
+ "into-attr-derive",
+ "pest",
+ "pest_derive",
+ "rand",
+ "tempfile",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +719,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "into-attr"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b48c537e49a709e678caec3753a7dba6854661a1eaa27675024283b3f8b376"
+dependencies = [
+ "dot-structures",
+]
+
+[[package]]
+name = "into-attr-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecac7c1ae6cd2c6a3a64d1061a8bdc7f52ff62c26a831a2301e54c1b5d70d5b1"
+dependencies = [
+ "dot-generator",
+ "dot-structures",
+ "into-attr",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1030,6 +1083,51 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pest"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1402,6 +1500,7 @@ dependencies = [
  "derive-getters",
  "flate2",
  "futures",
+ "graphviz-rust",
  "itertools",
  "num-traits",
  "opencv",
@@ -1673,6 +1772,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ futures = { version = "0.3.28", default-features = false, features = ["std"] }# 
 toml = "0.8.1" # Configuration file
 serde = { version = "1.0.189", features = ["derive"] } # Config serial handling
 bytes = "1.5.0" # Byte buffering
+uuid = { version = "1.5.0", features = ["v4", "fast-rng"] } # Unique IDs
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0" # Floating point eq

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,15 @@ path = "src/lib.rs"
 name = "sw8s_rust"
 path = "src/main.rs"
 
+[[bin]]
+name = "sw8s_rust_graphs"
+path = "src/graph_main.rs"
+required-features = ["graphing"]
+
 [features]
 jetson = []
 logging = []
+graphing = ["dep:graphviz-rust"]
 
 [dependencies]
 opencv = "0.85.3" # Vision processing
@@ -31,6 +37,7 @@ toml = "0.8.1" # Configuration file
 serde = { version = "1.0.189", features = ["derive"] } # Config serial handling
 bytes = "1.5.0" # Byte buffering
 uuid = { version = "1.5.0", features = ["v4", "fast-rng"] } # Unique IDs
+graphviz-rust = { version = "0.6.6", optional = true } # Drawing graphs
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0" # Floating point eq

--- a/src/graph_main.rs
+++ b/src/graph_main.rs
@@ -1,0 +1,22 @@
+use futures::{stream, StreamExt};
+use sw8s_rust_lib::missions::graph::{dot_file, draw_svg};
+use sw8s_rust_lib::missions::{action_context::EmptyActionContext, basic::descend_and_go_forward};
+use tokio::{fs::write, join};
+
+#[tokio::main]
+async fn main() {
+    let context = EmptyActionContext;
+    // (name, action) pairs to draw
+    let actions = vec![("descend_and_go_forward", descend_and_go_forward(&context))];
+
+    stream::iter(actions)
+        .for_each(|(name, act)| async move {
+            let (res1, res2) = join!(
+                write(name.to_string() + ".svg", draw_svg(&act).unwrap()),
+                write(name.to_string() + ".dot", dot_file(&act))
+            );
+            res1.unwrap();
+            res2.unwrap();
+        })
+        .await;
+}

--- a/src/missions/action.rs
+++ b/src/missions/action.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use std::{marker::PhantomData, sync::Arc, thread};
-use tokio::{join, runtime::Handle, sync::Mutex, try_join};
+use tokio::{join, runtime::Handle, sync::Mutex};
 use uuid::Uuid;
 
 use super::graph::{stripped_type, DotString};

--- a/src/missions/action_context.rs
+++ b/src/missions/action_context.rs
@@ -23,9 +23,9 @@ pub trait GetMainElectronicsBoard: Send + Sync {
 }
 
 #[derive(Debug)]
-struct EmptyActionContext;
+pub struct EmptyActionContext;
 
-struct FullActionContext<T: AsyncWriteExt + Unpin + Send, U: MatSource> {
+pub struct FullActionContext<T: AsyncWriteExt + Unpin + Send, U: MatSource> {
     control_board: ControlBoard<T>,
     main_electronics_board: MainElectronicsBoard,
     frame_source: U,

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -1,5 +1,5 @@
 use super::{
-    action::{Action, ActionConcurrent, ActionExec, ActionParallel, ActionSequence},
+    action::{Action, ActionExec, ActionSequence},
     meb::WaitArm,
     movement::Descend,
     movement::StraightMovement,

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -34,7 +34,7 @@ impl DelayAction {
  *
  **/
 
-fn descend_and_go_forward<T: Send + Sync>(context: &T) -> impl Action + '_ {
+pub fn descend_and_go_forward<T: Send + Sync>(context: &T) -> impl Action + '_ {
     let depth: f32 = -1.0;
 
     // time in seconds that each action will wait until before continuing onto the next action.
@@ -57,4 +57,3 @@ fn descend_and_go_forward<T: Send + Sync>(context: &T) -> impl Action + '_ {
         ),
     )
 }
-

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use tokio::time::{sleep, Duration};
 
 #[derive(Debug)]
-struct DelayAction {
+pub struct DelayAction {
     delay: f32, // delay in seconds before the next action occurs.
 }
 

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -18,7 +18,7 @@ impl Action for DelayAction {}
 
 #[async_trait]
 impl ActionExec<()> for DelayAction {
-    async fn execute(self) -> (){
+    async fn execute(&mut self) -> (){
         sleep(Duration::from_secs_f32(self.delay)).await;
     }
 }

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -1,82 +1,60 @@
 use super::{
-    action::{Action, ActionExec, ActionConcurrent, ActionParallel, ActionSequence},
+    action::{Action, ActionConcurrent, ActionExec, ActionParallel, ActionSequence},
     meb::WaitArm,
     movement::Descend,
     movement::StraightMovement,
-    movement::ZeroMovement
+    movement::ZeroMovement,
 };
 use async_trait::async_trait;
 use tokio::time::{sleep, Duration};
 
-
 #[derive(Debug)]
 struct DelayAction {
-    delay: f32 // delay in seconds before the next action occurs.
+    delay: f32, // delay in seconds before the next action occurs.
 }
 
 impl Action for DelayAction {}
 
 #[async_trait]
 impl ActionExec<()> for DelayAction {
-    async fn execute(&mut self) -> (){
+    async fn execute(&mut self) -> () {
         sleep(Duration::from_secs_f32(self.delay)).await;
     }
 }
 
 impl DelayAction {
     pub const fn new(delay: f32) -> Self {
-        Self {
-            delay
-        }
+        Self { delay }
     }
 }
 
-
-
-
-/// Example function for Action system
-///
-/// Runs two nested actions in order: Waiting for arm and descending in
-/// parallel, followed by waiting for arm and descending concurrently.
-pub fn initial_descent<T: Send + Sync>(context: &T) -> impl Action + '_ {
-    ActionSequence::<T, T, _, _>::new(
-        ActionParallel::<T, T, _, _>::new(
-            WaitArm::new(context), 
-        Descend::new(context, -0.5)
-    ),
-        ActionConcurrent::<T, T, _, _>::new(
-            WaitArm::new(context), 
-        Descend::new(context, -1.0)
-    ),
-    )
-}
-
 /**
- * 
- * descends and goes forward for a certain duration 
- * 
+ *
+ * descends and goes forward for a certain duration
+ *
  **/
 
 fn descend_and_go_forward<T: Send + Sync>(context: &T) -> impl Action + '_ {
-    let depth: f32 = -1.0; 
+    let depth: f32 = -1.0;
 
-    // time in seconds that each action will wait until before continuing onto the next action. 
-    let dive_duration = 5.0; 
+    // time in seconds that each action will wait until before continuing onto the next action.
+    let dive_duration = 5.0;
     let forward_duration = 10.0;
     ActionSequence::<T, T, _, _>::new(
         WaitArm::new(context),
-        ActionSequence::<T,T,_,_>::new(
-            ActionSequence::<T,T,_,_>::new(
+        ActionSequence::<T, T, _, _>::new(
+            ActionSequence::<T, T, _, _>::new(
                 Descend::new(context, depth),
-                DelayAction::new(dive_duration)
-            ), 
-            ActionSequence::<T,T,_,_>::new(
-                ActionSequence::<T,T,_,_>::new(
+                DelayAction::new(dive_duration),
+            ),
+            ActionSequence::<T, T, _, _>::new(
+                ActionSequence::<T, T, _, _>::new(
                     StraightMovement::new(context, depth, true),
-                    DelayAction::new(forward_duration)
+                    DelayAction::new(forward_duration),
                 ),
-                ZeroMovement::new(context, depth)
-            )
-        )
+                ZeroMovement::new(context, depth),
+            ),
+        ),
     )
 }
+

--- a/src/missions/example.rs
+++ b/src/missions/example.rs
@@ -3,7 +3,9 @@ use async_trait::async_trait;
 use super::{
     action::{
         Action, ActionConcurrent, ActionConditional, ActionExec, ActionParallel, ActionSequence,
+        RaceAction,
     },
+    basic::DelayAction,
     meb::WaitArm,
     movement::Descend,
 };
@@ -28,6 +30,25 @@ pub fn always_wait<T: Send + Sync>(context: &T) -> impl Action + '_ {
         AlwaysTrue::new(),
         WaitArm::new(context),
         Descend::new(context, -0.5),
+    )
+}
+
+pub fn sequence_conditional<T: Send + Sync>(context: &T) -> impl Action + '_ {
+    ActionSequence::<T, T, _, _>::new(
+        ActionSequence::<T, T, _, _>::new(WaitArm::new(context), Descend::new(context, -1.0)),
+        ActionConditional::<T, _, _, _>::new(
+            AlwaysTrue::new(),
+            WaitArm::new(context),
+            Descend::new(context, -0.5),
+        ),
+    )
+}
+
+pub fn race_conditional<T: Send + Sync>(context: &T) -> impl Action + '_ {
+    ActionConditional::<T, _, _, _>::new(
+        AlwaysTrue::new(),
+        WaitArm::new(context),
+        RaceAction::new(Descend::new(context, -0.5), DelayAction::new(1.0)),
     )
 }
 

--- a/src/missions/example.rs
+++ b/src/missions/example.rs
@@ -1,0 +1,50 @@
+use async_trait::async_trait;
+
+use super::{
+    action::{
+        Action, ActionConcurrent, ActionConditional, ActionExec, ActionParallel, ActionSequence,
+    },
+    meb::WaitArm,
+    movement::Descend,
+};
+
+/// Example function for Action system
+///
+/// Runs two nested actions in order: Waiting for arm and descending in
+/// parallel, followed by waiting for arm and descending concurrently.
+pub fn initial_descent<T: Send + Sync>(context: &T) -> impl Action + '_ {
+    ActionSequence::<T, T, _, _>::new(
+        ActionParallel::<T, T, _, _>::new(WaitArm::new(context), Descend::new(context, -0.5)),
+        ActionConcurrent::<T, T, _, _>::new(WaitArm::new(context), Descend::new(context, -1.0)),
+    )
+}
+
+/// Example function for Action system
+///
+/// Runs two nested actions in order: Waiting for arm and descending in
+/// parallel, followed by waiting for arm and descending concurrently.
+pub fn always_wait<T: Send + Sync>(context: &T) -> impl Action + '_ {
+    ActionConditional::<T, _, _, _>::new(
+        AlwaysTrue::new(),
+        WaitArm::new(context),
+        Descend::new(context, -0.5),
+    )
+}
+
+#[derive(Debug)]
+struct AlwaysTrue {}
+
+impl AlwaysTrue {
+    pub fn new() -> Self {
+        AlwaysTrue {}
+    }
+}
+
+impl Action for AlwaysTrue {}
+
+#[async_trait]
+impl ActionExec<bool> for AlwaysTrue {
+    async fn execute(&mut self) -> bool {
+        true
+    }
+}

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -1,0 +1,65 @@
+use std::any::type_name;
+use uuid::Uuid;
+
+use super::action::Action;
+
+pub fn stripped_type<T: ?Sized>() -> &'static str {
+    let mut raw = type_name::<T>();
+    // Remove generic signatures
+    if let Some(idx) = raw.find('<') {
+        raw = &raw[0..idx];
+    }
+    // Remove path
+    if let Some(idx) = raw.rfind(':') {
+        raw = &raw[idx + 1..];
+    }
+    raw
+}
+
+/// Contains information for dot (graphviz) graphing
+#[derive(Debug)]
+pub struct DotString {
+    pub head_id: Uuid,
+    pub tail_ids: Vec<Uuid>,
+    pub body: String,
+}
+
+impl DotString {
+    pub fn prepend(&mut self, other: &Self) {
+        self.body = other.body.clone() + "\n" + &self.body;
+    }
+
+    pub fn append(&mut self, other: &Self) {
+        self.body.push('\n');
+        self.body.push_str(&other.body);
+    }
+}
+
+pub fn dot_file<T: Action>(act: &T) -> String {
+    let header = "digraph G {\nsplines = false;\n".to_string();
+    header + &act.dot_string().body + "\n}"
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::missions::{
+        action_context::EmptyActionContext,
+        example::{always_wait, initial_descent},
+    };
+
+    use super::*;
+
+    #[test]
+    fn dot_conditional() {
+        let action = always_wait(&EmptyActionContext {});
+        let file = dot_file(&action);
+        println!("{file}");
+    }
+
+    #[test]
+    fn dot_file_basic() {
+        let action = initial_descent(&EmptyActionContext {});
+        let file = dot_file(&action);
+        println!("{file}");
+    }
+}

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -1,6 +1,9 @@
 use std::any::type_name;
 use uuid::Uuid;
 
+#[cfg(feature = "graphing")]
+use graphviz_rust::{cmd::Format, exec, parse, printer::PrinterContext};
+
 use super::action::Action;
 
 pub fn stripped_type<T: ?Sized>() -> &'static str {
@@ -40,48 +43,11 @@ pub fn dot_file<T: Action>(act: &T) -> String {
     header + &act.dot_string().body + "}"
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::missions::{
-        action_context::EmptyActionContext,
-        basic::descend_and_go_forward,
-        example::{always_wait, initial_descent, race_conditional, sequence_conditional},
-    };
-
-    use super::*;
-
-    #[test]
-    fn dot_conditional() {
-        let action = always_wait(&EmptyActionContext {});
-        let file = dot_file(&action);
-        println!("{file}");
-    }
-
-    #[test]
-    fn dot_sequence_conditional() {
-        let action = sequence_conditional(&EmptyActionContext {});
-        let file = dot_file(&action);
-        println!("{file}");
-    }
-
-    #[test]
-    fn dot_race_conditional() {
-        let action = race_conditional(&EmptyActionContext {});
-        let file = dot_file(&action);
-        println!("{file}");
-    }
-
-    #[test]
-    fn dot_file_basic() {
-        let action = initial_descent(&EmptyActionContext {});
-        let file = dot_file(&action);
-        println!("{file}");
-    }
-
-    #[test]
-    fn dot_descend_forward() {
-        let action = descend_and_go_forward(&EmptyActionContext {});
-        let file = dot_file(&action);
-        println!("{file}");
-    }
+#[cfg(feature = "graphing")]
+pub fn draw_svg<T: Action>(act: &T) -> std::io::Result<String> {
+    exec(
+        parse(&dot_file(act)).unwrap(),
+        &mut PrinterContext::default(),
+        vec![Format::Svg.into()],
+    )
 }

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -44,6 +44,7 @@ pub fn dot_file<T: Action>(act: &T) -> String {
 mod tests {
     use crate::missions::{
         action_context::EmptyActionContext,
+        basic::descend_and_go_forward,
         example::{always_wait, initial_descent, race_conditional, sequence_conditional},
     };
 
@@ -73,6 +74,13 @@ mod tests {
     #[test]
     fn dot_file_basic() {
         let action = initial_descent(&EmptyActionContext {});
+        let file = dot_file(&action);
+        println!("{file}");
+    }
+
+    #[test]
+    fn dot_descend_forward() {
+        let action = descend_and_go_forward(&EmptyActionContext {});
         let file = dot_file(&action);
         println!("{file}");
     }

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -19,7 +19,7 @@ pub fn stripped_type<T: ?Sized>() -> &'static str {
 /// Contains information for dot (graphviz) graphing
 #[derive(Debug)]
 pub struct DotString {
-    pub head_id: Uuid,
+    pub head_ids: Vec<Uuid>,
     pub tail_ids: Vec<Uuid>,
     pub body: String,
 }
@@ -37,14 +37,14 @@ impl DotString {
 
 pub fn dot_file<T: Action>(act: &T) -> String {
     let header = "digraph G {\nsplines = false;\n".to_string();
-    header + &act.dot_string().body + "\n}"
+    header + &act.dot_string().body + "}"
 }
 
 #[cfg(test)]
 mod tests {
     use crate::missions::{
         action_context::EmptyActionContext,
-        example::{always_wait, initial_descent},
+        example::{always_wait, initial_descent, race_conditional, sequence_conditional},
     };
 
     use super::*;
@@ -52,6 +52,20 @@ mod tests {
     #[test]
     fn dot_conditional() {
         let action = always_wait(&EmptyActionContext {});
+        let file = dot_file(&action);
+        println!("{file}");
+    }
+
+    #[test]
+    fn dot_sequence_conditional() {
+        let action = sequence_conditional(&EmptyActionContext {});
+        let file = dot_file(&action);
+        println!("{file}");
+    }
+
+    #[test]
+    fn dot_race_conditional() {
+        let action = race_conditional(&EmptyActionContext {});
         let file = dot_file(&action);
         println!("{file}");
     }

--- a/src/missions/meb.rs
+++ b/src/missions/meb.rs
@@ -24,7 +24,7 @@ impl<T> Action for WaitArm<'_, T> {}
 #[async_trait]
 impl<T: GetMainElectronicsBoard> ActionExec<()> for WaitArm<'_, T> {
     /// Wait for system to be armed
-    async fn execute(self) {
+    async fn execute(&mut self) {
         while !self
             .context
             .get_main_electronics_board()

--- a/src/missions/mod.rs
+++ b/src/missions/mod.rs
@@ -1,6 +1,8 @@
 pub mod action;
 pub mod action_context;
 pub mod basic;
+pub mod example;
+pub mod graph;
 pub mod meb;
 pub mod movement;
 pub mod vision;

--- a/src/missions/movement.rs
+++ b/src/missions/movement.rs
@@ -39,7 +39,7 @@ impl<T> ActionMod<f32> for Descend<T> {
 
 #[async_trait]
 impl<T: GetControlBoard<SerialStream>> ActionExec<Result<()>> for Descend<T> {
-    async fn execute(self) -> Result<()> {
+    async fn execute(&mut self) -> Result<()> {
         self.context
             .get_control_board()
             .stability_2_speed_set(0.0, 0.0, 0.0, 0.0, 0.0, self.target_depth)

--- a/src/missions/movement.rs
+++ b/src/missions/movement.rs
@@ -76,7 +76,7 @@ impl<T> StraightMovement<T> {
 
 #[async_trait]
 impl<T: GetControlBoard<SerialStream>> ActionExec<Result<()>> for StraightMovement<T> {
-    async fn execute(self) -> Result<()> {
+    async fn execute(&mut self) -> Result<()> {
         let mut speed:f32 = 0.5; 
         if !self.forward {
             // Eric Liu is a very talented programmer and utilizes the most effective linear programming techniques from the FIRST™ Robotics Competition.
@@ -111,7 +111,7 @@ impl<T> ZeroMovement<T> {
 
 #[async_trait]
 impl<T: GetControlBoard<SerialStream>> ActionExec<Result<()>> for ZeroMovement<T> {
-    async fn execute(self) -> Result<()> {
+    async fn execute(&mut self) -> Result<()> {
         self.context
         .get_control_board()
         .stability_2_speed_set(0.0, 0.0, 0.0, 0.0, 0.0, self.target_depth)

--- a/src/missions/movement.rs
+++ b/src/missions/movement.rs
@@ -47,12 +47,11 @@ impl<T: GetControlBoard<SerialStream>> ActionExec<Result<()>> for Descend<T> {
     }
 }
 
-
 #[derive(Debug)]
 pub struct StraightMovement<T> {
     context: T,
     target_depth: f32,
-    forward: bool
+    forward: bool,
 }
 impl<T> Action for StraightMovement<T> {}
 
@@ -61,7 +60,7 @@ impl<T> StraightMovement<T> {
         Self {
             context,
             target_depth,
-            forward
+            forward,
         }
     }
 
@@ -69,15 +68,15 @@ impl<T> StraightMovement<T> {
         Self {
             context,
             target_depth: 0.0,
-            forward: false
-        }   
+            forward: false,
+        }
     }
 }
 
 #[async_trait]
 impl<T: GetControlBoard<SerialStream>> ActionExec<Result<()>> for StraightMovement<T> {
     async fn execute(&mut self) -> Result<()> {
-        let mut speed:f32 = 0.5; 
+        let mut speed: f32 = 0.5;
         if !self.forward {
             // Eric Liu is a very talented programmer and utilizes the most effective linear programming techniques from the FIRST™ Robotics Competition.
             // let speeed: f32 = speed;
@@ -95,16 +94,15 @@ impl<T: GetControlBoard<SerialStream>> ActionExec<Result<()>> for StraightMoveme
 #[derive(Debug)]
 pub struct ZeroMovement<T> {
     context: T,
-    target_depth: f32
+    target_depth: f32,
 }
 impl<T> Action for ZeroMovement<T> {}
-
 
 impl<T> ZeroMovement<T> {
     pub fn new(context: T, target_depth: f32) -> Self {
         Self {
             context,
-            target_depth
+            target_depth,
         }
     }
 }
@@ -113,8 +111,8 @@ impl<T> ZeroMovement<T> {
 impl<T: GetControlBoard<SerialStream>> ActionExec<Result<()>> for ZeroMovement<T> {
     async fn execute(&mut self) -> Result<()> {
         self.context
-        .get_control_board()
-        .stability_2_speed_set(0.0, 0.0, 0.0, 0.0, 0.0, self.target_depth)
-        .await
+            .get_control_board()
+            .stability_2_speed_set(0.0, 0.0, 0.0, 0.0, 0.0, self.target_depth)
+            .await
     }
 }

--- a/src/missions/vision.rs
+++ b/src/missions/vision.rs
@@ -35,7 +35,7 @@ impl<T: MatSource, V: Num + From<usize> + Send + Sync, U: VisualDetector<V> + Se
 where
     U::Position: RelPos<Number = V>,
 {
-    async fn execute(mut self) -> Result<Offset2D<V>> {
+    async fn execute(&mut self) -> Result<Offset2D<V>> {
         let detections = self.model.detect_unique(&self.context.get_mat().await)?;
 
         let positions: Vec<_> = detections


### PR DESCRIPTION
Adds functions to generate graphviz dot-format layouts for any given action. Uses a default generation for "Action" and then overrides that in the meta-Actions that combine other actions. Adds a feature for graphviz generation and a new binary `sw8s_rust_graphs` that uses graphviz-rust to write out .dot and .svg files for each graph (avoiding the need to feed .dot files into `dot` for the SVG output). Both of these formats can be tweaked by hand if the automated layout is poor.

Graphs are constructed by adding together graphviz strings and a new special formattings. Each base Action labels itself with its struct name and gets a Uuid. The meta-actions then string together these Uuids to draw connections. No Action produces more than one head node at the moment (to make conditionals more legible), but the capability is left in the logic.

Also has minor fixes to the internals of logic.

Here is an example of the SVG output.
![descend_and_go_forward](https://github.com/ncsurobotics/SW8S-Rust/assets/46354948/7164f043-12d0-4efe-a7ac-ef93e607fbaf)