### PR TITLE
Fix Action Graphing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,4 +27,4 @@ jobs:
                                  libopencv-dev \
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tests/godot_sim/
 config.toml
 vendor
 util/.sw8_ssh_identity
+graphs
 
 # Ignore JetBrains IDE config folder
 .idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1520,7 @@ dependencies = [
  "itertools",
  "num-traits",
  "opencv",
+ "paste",
  "proc-macro2",
  "quote",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1011,7 +1011,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1115,7 +1115,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1155,18 +1155,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1363,7 +1363,7 @@ checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1514,8 +1514,11 @@ dependencies = [
  "itertools",
  "num-traits",
  "opencv",
+ "proc-macro2",
+ "quote",
  "reqwest",
  "serde",
+ "syn 2.0.39",
  "tar",
  "tokio",
  "tokio-serial",
@@ -1537,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1608,7 +1611,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1670,7 +1673,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1878,7 +1881,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -1912,7 +1915,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sw8s_rust"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,7 +22,7 @@ required-features = ["graphing"]
 [features]
 jetson = []
 logging = []
-graphing = ["dep:graphviz-rust"]
+graphing = ["dep:graphviz-rust", "dep:quote", "dep:syn", "dep:proc-macro2"]
 
 [dependencies]
 opencv = { version = "0.86.1", default-features = false, features = ["dnn", "imgcodecs", "imgproc", "videoio"] } # Vision processing
@@ -38,6 +39,11 @@ serde = { version = "1.0.190", features = ["derive"] } # Config serial handling
 bytes = "1.5.0" # Byte buffering
 uuid = { version = "1.5.0", features = ["v4", "fast-rng"] } # Unique IDs
 graphviz-rust = { version = "0.6.6", optional = true } # Drawing graphs
+
+[build-dependencies]
+quote = { version = "1.0.33", optional = true }
+syn = { version = "2.0.39", features = ["full", "fold"], optional = true }
+proc-macro2 = { version = "1.0.69", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0" # Floating point eq

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "sw8s_rust"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
+default-run = "sw8s_rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0.192", features = ["derive"] } # Config serial handling
 bytes = "1.5.0" # Byte buffering
 uuid = { version = "1.5.0", features = ["v4", "fast-rng"] } # Unique IDs
 graphviz-rust = { version = "0.6.6", optional = true } # Drawing graphs
+paste = { version = "1.0.14", optional = true } # Concat identifiers
 
 [build-dependencies]
 quote = { version = "1.0.33", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -95,7 +95,6 @@ mod graphing {
         println!("out_dir: {out_dir}");
         let out_path_raw = out_dir + "/graph_missions";
         let out_path = Path::new(&out_path_raw);
-        create_dir_all(out_path).unwrap();
 
         // Get parseable file clones
         let mission_files = get_files("src/missions".into())
@@ -129,6 +128,8 @@ mod graphing {
                         + "]}";
                 let file_contents =
                     quote! { use sw8s_rust_lib::missions::action::Action as GraphAction; #file };
+                let output_loc = out_path.join(path.strip_prefix::<PathBuf>("src/missions".into()).unwrap());
+                create_dir_all(output_loc.parent().unwrap()).unwrap();
                 write(
                     out_path.join(path.strip_prefix::<PathBuf>("src/missions".into()).unwrap()),
                     format!("{} {}", file_contents, actions_str),

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,119 @@
+#[cfg(feature = "graphing")]
+mod graphing {
+    use proc_macro2::Span;
+    use quote::quote;
+    use std::env::var_os;
+    use std::ffi::OsStr;
+    use std::fs::{create_dir_all, read_dir, read_to_string, write};
+    use std::path::{Path, PathBuf};
+    use syn::fold::{fold_item_fn, fold_use_path, Fold};
+    use syn::punctuated::Punctuated;
+    use syn::{
+        parse_file, Ident, ItemFn, ReturnType, Token, Type, TypeParamBound, UsePath, UseTree,
+    };
+
+    struct ReplaceActionExec;
+
+    impl Fold for ReplaceActionExec {
+        // Replace every impl ActionExec with impl Action
+        // Uses GraphAction to always be sure Action is imported
+        // Also strips generics
+        fn fold_item_fn(&mut self, i: ItemFn) -> ItemFn {
+            let mut j = i.clone();
+            if let ReturnType::Type(_, ref mut ret_type) = j.sig.output {
+                if let Type::ImplTrait(ref mut impl_trait) = **ret_type {
+                    impl_trait.bounds.iter_mut().for_each(|bound| {
+                        if let TypeParamBound::Trait(ref mut t) = bound {
+                            t.path.segments.iter_mut().for_each(|seg| {
+                                if seg.ident == "ActionExec" {
+                                    seg.ident = Ident::new("GraphAction", seg.ident.span());
+
+                                    j.sig
+                                        .generics
+                                        .type_params_mut()
+                                        .for_each(|param| param.bounds = Punctuated::new());
+                                }
+                            });
+                        }
+                    });
+                }
+            };
+            // Call on the regular recursion
+            fold_item_fn(self, j)
+        }
+
+        // Replace local paths with global paths
+        fn fold_use_path(&mut self, i: syn::UsePath) -> syn::UsePath {
+            println!("Folding path segment: {:?}", i.ident);
+            let mut j = i.clone();
+            match j.ident.to_string().as_str() {
+                "crate" => j.ident = Ident::new("sw8s_rust_lib", j.ident.span()),
+                "super" => {
+                    j.ident = Ident::new("sw8s_rust_lib", j.ident.span());
+                    j.tree = Box::new(UseTree::Path(UsePath {
+                        ident: Ident::new("missions", Span::call_site()),
+                        colon2_token: Token![::](Span::call_site()),
+                        tree: j.tree,
+                    }));
+                }
+                _ => (),
+            }
+            // Call on the regular recursion
+            fold_use_path(self, j)
+        }
+    }
+
+    fn get_files(file: PathBuf) -> Vec<PathBuf> {
+        if file.is_file() {
+            vec![file]
+        } else if file.is_dir() {
+            read_dir(file)
+                .unwrap()
+                .flat_map(|inner| get_files(inner.unwrap().path()))
+                .collect()
+        } else {
+            vec![]
+        }
+    }
+
+    pub fn graphing_variants() {
+        // Command to cargo
+        println!("cargo:rerun-if-changed=src/missions");
+
+        // Calculating output dir
+        let out_dir = var_os("OUT_DIR").unwrap().to_str().unwrap().to_string();
+        println!("out_dir: {out_dir}");
+        let out_path_raw = out_dir + "/graph_missions";
+        let out_path = Path::new(&out_path_raw);
+        create_dir_all(out_path).unwrap();
+
+        // Get parseable file clones
+        let mission_files = get_files("src/missions".into())
+            .into_iter()
+            .filter(|path| path.extension().unwrap_or(OsStr::new("")) == "rs")
+            .map(|path| {
+                println!("Path: {:?}", path);
+                (
+                    path.clone(),
+                    parse_file(&read_to_string(path).unwrap()).unwrap().clone(),
+                )
+            });
+
+        // Modify clones and write to output dir
+        mission_files
+            .map(|(path, file)| (path, ReplaceActionExec.fold_file(file)))
+            .for_each(|(path, file)| {
+                write(
+                    out_path.join(path.strip_prefix::<PathBuf>("src/missions".into()).unwrap()),
+                    quote! { use sw8s_rust_lib::missions::action::Action as GraphAction; #file }
+                        .to_string(),
+                )
+                .unwrap()
+            });
+    }
+}
+
+fn main() {
+    #[cfg(feature = "graphing")]
+    graphing::graphing_variants();
+}

--- a/build.rs
+++ b/build.rs
@@ -28,10 +28,11 @@ mod graphing {
                                 if seg.ident == "ActionExec" {
                                     seg.ident = Ident::new("GraphAction", seg.ident.span());
 
-                                    j.sig
-                                        .generics
-                                        .type_params_mut()
-                                        .for_each(|param| param.bounds = Punctuated::new());
+                                    j.sig.generics.type_params_mut().for_each(|param| {
+                                        if param.ident == "Con" {
+                                            param.bounds = Punctuated::new()
+                                        }
+                                    });
                                 }
                             });
                         }

--- a/src/graph_main.rs
+++ b/src/graph_main.rs
@@ -1,7 +1,13 @@
 use futures::{stream, StreamExt};
+use sw8s_rust_lib::missions::action_context::EmptyActionContext;
 use sw8s_rust_lib::missions::graph::{dot_file, draw_svg};
-use sw8s_rust_lib::missions::{action_context::EmptyActionContext, basic::descend_and_go_forward};
 use tokio::{fs::write, join};
+
+#[allow(warnings)]
+mod generated_actions {
+    include!(concat!(env!("OUT_DIR"), "/graph_missions/basic.rs"));
+}
+use generated_actions::descend_and_go_forward;
 
 #[tokio::main]
 async fn main() {

--- a/src/graph_main.rs
+++ b/src/graph_main.rs
@@ -1,6 +1,7 @@
 use std::fs::create_dir_all;
 
 use futures::{stream, StreamExt};
+use sw8s_rust_lib::missions::action::Action;
 use sw8s_rust_lib::missions::action_context::EmptyActionContext;
 use sw8s_rust_lib::missions::graph::{dot_file, draw_svg};
 use tokio::{fs::write, join};
@@ -9,23 +10,30 @@ use tokio::{fs::write, join};
 mod generated_actions {
     include!(concat!(env!("OUT_DIR"), "/graph_missions/basic.rs"));
 }
-use generated_actions::descend_and_go_forward;
+use generated_actions::{descend_and_go_forward, gate_run};
+
+const CONTEXT: EmptyActionContext = EmptyActionContext;
 
 #[tokio::main]
 async fn main() {
-    let context = EmptyActionContext;
     create_dir_all("graphs/").unwrap();
     // (name, action) pairs to draw
-    let actions = vec![("descend_and_go_forward", descend_and_go_forward(&context))];
+    let actions: Vec<(&str, Box<dyn Action>)> = vec![
+        (
+            "descend_and_go_forward",
+            Box::new(descend_and_go_forward(&CONTEXT)),
+        ),
+        ("gate_run", Box::new(gate_run(&CONTEXT))),
+    ];
 
     stream::iter(actions)
         .for_each(|(name, act)| async move {
             let (res1, res2) = join!(
                 write(
                     "graphs/".to_string() + &name + ".svg",
-                    draw_svg(&act).unwrap()
+                    draw_svg(&*act).unwrap()
                 ),
-                write("graphs/".to_string() + &name + ".dot", dot_file(&act))
+                write("graphs/".to_string() + &name + ".dot", dot_file(&*act))
             );
             res1.unwrap();
             res2.unwrap();

--- a/src/graph_main.rs
+++ b/src/graph_main.rs
@@ -1,3 +1,5 @@
+use std::fs::create_dir_all;
+
 use futures::{stream, StreamExt};
 use sw8s_rust_lib::missions::action_context::EmptyActionContext;
 use sw8s_rust_lib::missions::graph::{dot_file, draw_svg};
@@ -12,14 +14,18 @@ use generated_actions::descend_and_go_forward;
 #[tokio::main]
 async fn main() {
     let context = EmptyActionContext;
+    create_dir_all("graphs/").unwrap();
     // (name, action) pairs to draw
     let actions = vec![("descend_and_go_forward", descend_and_go_forward(&context))];
 
     stream::iter(actions)
         .for_each(|(name, act)| async move {
             let (res1, res2) = join!(
-                write(name.to_string() + ".svg", draw_svg(&act).unwrap()),
-                write(name.to_string() + ".dot", dot_file(&act))
+                write(
+                    "graphs/".to_string() + &name + ".svg",
+                    draw_svg(&act).unwrap()
+                ),
+                write("graphs/".to_string() + &name + ".dot", dot_file(&act))
             );
             res1.unwrap();
             res2.unwrap();

--- a/src/graph_main.rs
+++ b/src/graph_main.rs
@@ -2,7 +2,6 @@ use std::fs::create_dir_all;
 
 use futures::{stream, StreamExt};
 use paste::paste;
-use sw8s_rust_lib::missions::action::Action;
 use sw8s_rust_lib::missions::action_context::EmptyActionContext;
 use sw8s_rust_lib::missions::graph::{dot_file, draw_svg};
 use tokio::{fs::write, join};

--- a/src/graph_main.rs
+++ b/src/graph_main.rs
@@ -1,6 +1,7 @@
 use std::fs::create_dir_all;
 
 use futures::{stream, StreamExt};
+use paste::paste;
 use sw8s_rust_lib::missions::action::Action;
 use sw8s_rust_lib::missions::action_context::EmptyActionContext;
 use sw8s_rust_lib::missions::graph::{dot_file, draw_svg};
@@ -8,35 +9,49 @@ use tokio::{fs::write, join};
 
 #[allow(warnings)]
 mod generated_actions {
-    include!(concat!(env!("OUT_DIR"), "/graph_missions/basic.rs"));
+    pub mod basic {
+        include!(concat!(env!("OUT_DIR"), "/graph_missions/basic.rs"));
+    }
+    pub mod example {
+        include!(concat!(env!("OUT_DIR"), "/graph_missions/example.rs"));
+    }
 }
-use generated_actions::{descend_and_go_forward, gate_run};
 
 const CONTEXT: EmptyActionContext = EmptyActionContext;
+
+macro_rules! graph_actions {
+    ($($i:path),*) => {
+        vec![
+            $(
+            paste! {
+                (stringify!($i), generated_actions::[<$i>]::graph_actions(&CONTEXT))
+        }
+            ),*
+        ]
+    }
+}
 
 #[tokio::main]
 async fn main() {
     create_dir_all("graphs/").unwrap();
     // (name, action) pairs to draw
-    let actions: Vec<(&str, Box<dyn Action>)> = vec![
-        (
-            "descend_and_go_forward",
-            Box::new(descend_and_go_forward(&CONTEXT)),
-        ),
-        ("gate_run", Box::new(gate_run(&CONTEXT))),
-    ];
+    let actions = graph_actions!(basic, example);
 
     stream::iter(actions)
-        .for_each(|(name, act)| async move {
-            let (res1, res2) = join!(
-                write(
-                    "graphs/".to_string() + &name + ".svg",
-                    draw_svg(&*act).unwrap()
-                ),
-                write("graphs/".to_string() + &name + ".dot", dot_file(&*act))
-            );
-            res1.unwrap();
-            res2.unwrap();
+        .for_each(|(dir_name, action_set)| async move {
+            let dir = ("graphs/".to_string() + dir_name + "/").clone();
+            tokio::fs::create_dir_all(dir.clone()).await.unwrap();
+            stream::iter(action_set)
+                .map(|(name, act)| (dir.clone(), name, act))
+                .for_each(|(dir, name, act)| async move {
+                    let (res1, res2) = join!(
+                        write(dir.clone() + &name + ".svg", draw_svg(&*act).unwrap()),
+                        write(dir.clone() + &name + ".dot", dot_file(&*act))
+                    );
+                    res1.unwrap();
+                    res2.unwrap();
+                })
+                .await;
         })
         .await;
 }

--- a/src/missions/action.rs
+++ b/src/missions/action.rs
@@ -422,7 +422,7 @@ impl<V: Action, W: Action> Action for ActionConcurrent<V, W> {
             "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = blue;\n\"{}\" [label = \"Concurrent\", shape = box, fontcolor = blue, style = dashed];\n",
             Uuid::new_v4(),
             concurrent_head
-        ) + &format!("{}\" [label = \"Collect\", shape = box, fontcolor = blue, style = dashed];\n", concurrent_tail) +
+        ) + &format!("\"{}\" [label = \"Collect\", shape = box, fontcolor = blue, style = dashed];\n", concurrent_tail) +
             &first_str.body
             + &second_str.body;
 

--- a/src/missions/action.rs
+++ b/src/missions/action.rs
@@ -9,6 +9,10 @@ use super::graph::{stripped_type, DotString};
 
 /**
  * A trait for an action that can be executed.
+ *
+ * Functions returning Actions/ActionExec should be written with `-> impl ActionExec + '_` and
+ * using `Con` for the context generic. This allows the build script to strip out the context and
+ * create a mirrored version returning `-> impl Action +'_` for graphing.
  */
 pub trait Action {
     /// Represent this node in dot (graphviz) notation

--- a/src/missions/action.rs
+++ b/src/missions/action.rs
@@ -17,7 +17,11 @@ pub trait Action {
         DotString {
             head_ids: vec![id],
             tail_ids: vec![id],
-            body: format!("\"{}\" [label = \"{}\"];\n", id, stripped_type::<Self>()),
+            body: format!(
+                "\"{}\" [label = \"{}\", margin = 0];\n",
+                id,
+                stripped_type::<Self>()
+            ),
         }
     }
 }
@@ -257,7 +261,7 @@ impl<V: Action, W: Action> Action for ActionChain<V, W> {
         for tail in &first_str.tail_ids {
             for head in &second_str.head_ids {
                 body_str.push_str(&format!(
-                    "\"{}\" -> \"{}\" [color = purple, textcolor = purple, label = \"Pass Data\"];\n",
+                    "\"{}\" -> \"{}\" [color = purple, fontcolor = purple, label = \"Pass Data\"];\n",
                     tail, head
                 ))
             }
@@ -422,7 +426,7 @@ impl<V: Action, W: Action> Action for ActionConcurrent<V, W> {
             "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = blue;\n\"{}\" [label = \"Concurrent\", shape = box, fontcolor = blue, style = dashed];\n",
             Uuid::new_v4(),
             concurrent_head
-        ) + &format!("\"{}\" [label = \"Collect\", shape = box, fontcolor = blue, style = dashed];\n", concurrent_tail) +
+        ) + &format!("\"{}\" [label = \"Converge\", shape = box, fontcolor = blue, style = dashed];\n", concurrent_tail) +
             &first_str.body
             + &second_str.body;
 
@@ -526,10 +530,10 @@ impl<T: Action> Action for ActionWhile<T> {
 
         let mut body_str = action_str.body;
         for head in &action_str.head_ids {
-            body_str.push_str(&format!("\"{}\" [shape = diamond];\n", head));
             for tail in &action_str.tail_ids {
+                body_str.push_str(&format!("\"{}\" [shape = diamond];\n", tail));
                 body_str.push_str(&format!(
-                    "\"{}\":sw -> \"{}\":nw [label = \"True\"];\n",
+                    "\"{}\" -> \"{}\" [label = \"True\"];\n",
                     tail, head
                 ))
             }

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 
 use super::{
-    action::{
-        Action, ActionChain, ActionConcurrent, ActionExec, ActionSequence, ActionWhile,
-    },
+    action::{Action, ActionChain, ActionConcurrent, ActionExec, ActionSequence, ActionWhile},
     action_context::{GetControlBoard, GetMainElectronicsBoard},
     comms::StartBno055,
     example::AlwaysTrue,
@@ -52,9 +50,9 @@ impl DelayAction {
  *
  **/
 pub fn descend_and_go_forward<
-    T: Send + Sync + GetControlBoard<WriteHalf<SerialStream>> + GetMainElectronicsBoard,
+    Con: Send + Sync + GetControlBoard<WriteHalf<SerialStream>> + GetMainElectronicsBoard,
 >(
-    context: &T,
+    context: &Con,
 ) -> impl ActionExec + '_ {
     let depth: f32 = -1.0;
 
@@ -80,9 +78,9 @@ pub fn descend_and_go_forward<
 }
 
 pub fn gate_run<
-    T: Send + Sync + GetControlBoard<WriteHalf<SerialStream>> + GetMainElectronicsBoard + MatSource,
+    Con: Send + Sync + GetControlBoard<WriteHalf<SerialStream>> + GetMainElectronicsBoard + MatSource,
 >(
-    context: &T,
+    context: &Con,
 ) -> impl ActionExec + '_ {
     let depth: f32 = -1.0;
     let model = GatePoles::default();
@@ -91,7 +89,7 @@ pub fn gate_run<
         ActionConcurrent::new(descend_and_go_forward(context), StartBno055::new(context)),
         ActionWhile::new(ActionSequence::new(
             ActionChain::new(
-                VisionNormOffset::<T, GatePoles<OnnxModel>, f64>::new(context, model),
+                VisionNormOffset::<Con, GatePoles<OnnxModel>, f64>::new(context, model),
                 AdjustMovement::new(context, depth),
             ),
             AlwaysTrue::new(),

--- a/src/missions/example.rs
+++ b/src/missions/example.rs
@@ -16,9 +16,9 @@ use super::{
 /// Runs two nested actions in order: Waiting for arm and descending in
 /// parallel, followed by waiting for arm and descending concurrently.
 pub fn initial_descent<
-    T: Send + Sync + GetMainElectronicsBoard + GetControlBoard<WriteHalf<SerialStream>>,
+    Con: Send + Sync + GetMainElectronicsBoard + GetControlBoard<WriteHalf<SerialStream>>,
 >(
-    context: &T,
+    context: &Con,
 ) -> impl ActionExec + '_ {
     ActionSequence::new(
         ActionConcurrent::new(WaitArm::new(context), Descend::new(context, -0.5)),

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -39,7 +39,7 @@ impl DotString {
 }
 
 pub fn dot_file<T: ?Sized + Action>(act: &T) -> String {
-    let header = "digraph G {\nsplines = true;\n".to_string();
+    let header = "digraph G {\nsplines = true;\nnodesep = 1.0;\n".to_string();
     header + &act.dot_string().body + "}"
 }
 

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -39,7 +39,7 @@ impl DotString {
 }
 
 pub fn dot_file<T: ?Sized + Action>(act: &T) -> String {
-    let header = "digraph G {\nsplines = false;\n".to_string();
+    let header = "digraph G {\nsplines = true;\n".to_string();
     header + &act.dot_string().body + "}"
 }
 

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -38,13 +38,13 @@ impl DotString {
     }
 }
 
-pub fn dot_file<T: Action>(act: &T) -> String {
+pub fn dot_file<T: ?Sized + Action>(act: &T) -> String {
     let header = "digraph G {\nsplines = false;\n".to_string();
     header + &act.dot_string().body + "}"
 }
 
 #[cfg(feature = "graphing")]
-pub fn draw_svg<T: Action>(act: &T) -> std::io::Result<String> {
+pub fn draw_svg<T: ?Sized + Action>(act: &T) -> std::io::Result<String> {
     exec(
         parse(&dot_file(act)).unwrap(),
         &mut PrinterContext::default(),


### PR DESCRIPTION
Fixes the action graphing system, so that sw8s_rust_graphs works properly. Requires that all action-generating functions return `-> impl ActionExec + '_` and name the context generic `Con` (see modified existing code for examples).

The build.rs script parses the src/missions folder and creates a mirror version that transforms all `impl ActionExec + '_` to `impl Action + '_` with generic bounds removed. We can then pull those files in for graphing functionality (see `src/graph_main/rs`). Because this is a parsing solution it may be fragile: any test runner failures due to this parsed script should be ignored if all other tests pass.

List of alterations:
- New build.rs script
- Optional parsing dependencies (used for the `graphing` feature)
- Graph output improvements
- Convenience functions in generated files that make adding new graphs low maintenance
- `T` transformed to `Con` for `-> impl ActionExec` functions
- Plenty of macros and parsing weirdness
- Patched/Prettier graph output
- All current missions added to graph generation
- Set sw8s_rust to the default run binary

Example output, with the mission we ran at the last pool test:
![gate_run](https://github.com/ncsurobotics/SW8S-Rust/assets/46354948/396abca4-e84a-48f5-aa66-00bdc8810eee)