### PR TITLE
Make CI cached to speed up build times

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: llvm \
+            libclang-dev \
+            libopencv-dev
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -46,7 +52,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -28,15 +28,15 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
           components: clippy
           override: true
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -32,10 +32,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           components: clippy
-          override: true
       - uses: Swatinem/rust-cache@v2
 
       - name: Install required cargo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,13 +19,14 @@ jobs:
 
     - uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: libgstreamer1.0-dev llvm libclang-dev libopencv-dev
+        packages: aptitude \
+          llvm \
+          libclang-dev \
+          libopencv-dev
+    - name: Install gstreamer
+      run: sudo aptitude install -y libgstreamer1.0-dev
 
     - uses: dtolnay/rust-toolchain@stable
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
     - uses: Swatinem/rust-cache@v2
 
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
           llvm \
           libclang-dev \
           libopencv-dev
+        execute_install_scripts: true
     - name: Install gstreamer
       run: sudo aptitude install -y libgstreamer1.0-dev
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,16 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Install system requirements
-      run:  |
-        sudo apt-get update
-        sudo apt-get install -y aptitude
-        sudo aptitude install -y libgstreamer1.0-dev
-        sudo apt-get install -y  llvm \
-                                 libclang-dev \
-                                 libopencv-dev \
+    - uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: libgstreamer1.0-dev llvm libclang-dev libopencv-dev
+
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: Swatinem/rust-cache@v2
 
     - name: Run tests
       run: cargo test --all-features --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,12 @@ jobs:
           llvm \
           libclang-dev \
           libopencv-dev
-        execute_install_scripts: true
+
     - name: Install gstreamer
-      run: sudo aptitude install -y libgstreamer1.0-dev
+      run: |
+        sudo apt update
+        sudo apt install -y aptitude
+        sudo aptitude install -y libgstreamer1.0-dev
 
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2

--- a/src/comms/auv_control_board/response.rs
+++ b/src/comms/auv_control_board/response.rs
@@ -115,7 +115,7 @@ pub async fn write_log(messages: &[Vec<u8>], #[cfg(feature = "logging")] dump_fi
         .unwrap();
 
     for msg in messages.iter() {
-        file.write_all(&msg).await.unwrap()
+        file.write_all(msg).await.unwrap()
     }
 
     file.flush().await.unwrap();

--- a/src/comms/auv_control_board/response.rs
+++ b/src/comms/auv_control_board/response.rs
@@ -80,8 +80,8 @@ pub async fn get_messages<T>(
     serial_conn: &mut T,
     #[cfg(feature = "logging")] dump_file: &str,
 ) -> Vec<Vec<u8>>
-    where
-        T: AsyncReadExt + Unpin + Send,
+where
+    T: AsyncReadExt + Unpin + Send,
 {
     if serial_conn.read_buf(buffer).await.unwrap() != 0 {
         let mut messages = Vec::new();
@@ -92,7 +92,8 @@ pub async fn get_messages<T>(
             }
         }
 
-        #[cfg(feature = "logging")] {
+        #[cfg(feature = "logging")]
+        {
             write_log(&messages, dump_file).await;
         }
 
@@ -105,20 +106,16 @@ pub async fn get_messages<T>(
 }
 
 #[cfg(feature = "logging")]
-pub async fn write_log(messages: &Vec<Vec<u8>>, #[cfg(feature = "logging")] dump_file: &str) {
-    let mut file =
-        OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(dump_file)
-            .await
-            .unwrap();
+pub async fn write_log(messages: &[Vec<u8>], #[cfg(feature = "logging")] dump_file: &str) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dump_file)
+        .await
+        .unwrap();
 
     for msg in messages.iter() {
-        file
-            .write_all(&msg)
-            .await
-            .unwrap()
+        file.write_all(&msg).await.unwrap()
     }
 
     file.flush().await.unwrap();
@@ -137,22 +134,32 @@ mod tests {
         let mut buffer: Vec<u8> = Vec::with_capacity(512);
 
         assert_eq!(
-            stream::iter(get_messages(
-                &mut buffer,
-                &mut &*input,
-            #[cfg(feature = "logging")] "test.dat").await)
-                .collect::<Vec<Vec<u8>>>()
-                .await,
+            stream::iter(
+                get_messages(
+                    &mut buffer,
+                    &mut &*input,
+                    #[cfg(feature = "logging")]
+                    "test.dat"
+                )
+                .await
+            )
+            .collect::<Vec<Vec<u8>>>()
+            .await,
             vec![vec![]]
         );
 
         assert_eq!(
-            stream::iter(get_messages(
-                &mut buffer,
-                &mut &*input2,
-                #[cfg(feature = "logging")] "test.dat").await)
-                .collect::<Vec<Vec<u8>>>()
-                .await,
+            stream::iter(
+                get_messages(
+                    &mut buffer,
+                    &mut &*input2,
+                    #[cfg(feature = "logging")]
+                    "test.dat"
+                )
+                .await
+            )
+            .collect::<Vec<Vec<u8>>>()
+            .await,
             vec![vec![3]]
         );
     }
@@ -171,9 +178,6 @@ mod tests {
             get_messages(&mut buffer, &mut &*input2, dump_file).await;
         }
 
-        assert_eq!(
-            std::fs::read(dump_file).unwrap(),
-            vec![0, 1, 3, 5]
-        );
+        assert_eq!(std::fs::read(dump_file).unwrap(), vec![0, 1, 3, 5]);
     }
 }

--- a/src/missions/vision.rs
+++ b/src/missions/vision.rs
@@ -48,7 +48,7 @@ where
         {
             println!("Running detection...");
         }
-        
+
         #[allow(unused_mut)]
         let mut mat = self.context.get_mat().await;
         let detections = self.model.detect(&mat);


### PR DESCRIPTION
Our compile on CI is actually fairly fast, but this still saves some time on package install for the build command. Will save significantly more time on the clippy Action due to caching the compilation of the formatting tools.

The repository setting for clippy failures has also been escalated from errors to errors and warnings.