### PR TITLE
CI: get rid of `aptuitude`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,16 +19,10 @@ jobs:
 
     - uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: aptitude \
-          llvm \
+        packages: llvm \
           libclang-dev \
-          libopencv-dev
-
-    - name: Install gstreamer
-      run: |
-        sudo apt update
-        sudo apt install -y aptitude
-        sudo aptitude install -y libgstreamer1.0-dev
+          libopencv-dev \
+          libgstreamer1.0-dev
 
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Now that we are not installing with `apt` directly, I am wondering if we still need `aptitude`.