### PR TITLE
Revert "Bump the all-dependencies group with 4 updates"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -551,9 +551,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "graphviz-rust"
-version = "0.7.0"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f7a4f4b8db9d330c49744d0f98ce7c9a37e3e32a0d247a90338119b2040184"
+checksum = "27dafd1ac303e0dfb347a3861d9ac440859bab26ec2f534bbceb262ea492a1e0"
 dependencies = [
  "dot-generator",
  "dot-structures",
@@ -957,9 +957,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opencv"
-version = "0.88.4"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82171a36b8642ad249ab90a34dfa00148b0a5a77d4486b4821fe19ae6587a93a"
+checksum = "0285c64387094632ad1e8a12d7b1c494c63590eb41175eb5b61e5d5d506a03e4"
 dependencies = [
  "cc",
  "dunce",
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "opencv-binding-generator"
-version = "0.81.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1941efeef14b642f70c7d8294d12d340a60f03499961e24d4c0be5ca66c7bb"
+checksum = "d49ee21f650559a42d43aff2843677e81b94d44a7076f69693883f03aecc1325"
 dependencies = [
  "clang",
  "clang-sys",
@@ -1011,7 +1011,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1121,7 +1121,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1369,7 +1369,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1525,7 +1525,7 @@ dependencies = [
  "quote",
  "reqwest",
  "serde",
- "syn 2.0.41",
+ "syn 2.0.39",
  "tar",
  "tokio",
  "tokio-serial",
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1618,7 +1618,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1655,9 +1655,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1680,7 +1680,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1888,7 +1888,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -1922,7 +1922,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ logging = []
 graphing = ["dep:graphviz-rust", "dep:quote", "dep:syn", "dep:proc-macro2"]
 
 [dependencies]
-opencv = { version = "0.88.4", default-features = false, features = ["dnn", "imgcodecs", "imgproc", "videoio"] } # Vision processing
+opencv = { version = "0.88.1", default-features = false, features = ["dnn", "imgcodecs", "imgproc", "videoio"] } # Vision processing
 tokio-serial = "5.4.1" # Async serial comms
-tokio = { version = "1.35.0", features = ["full"] } # Async runtime
+tokio = { version = "1.34.0", features = ["full"] } # Async runtime
 anyhow = "1.0.75" # Error handling
 itertools = "0.12.0" # Enhance iterators
 num-traits = "0.2.17" # Numeric generics
@@ -39,12 +39,12 @@ toml = "0.8.8" # Configuration file
 serde = { version = "1.0.193", features = ["derive"] } # Config serial handling
 bytes = "1.5.0" # Byte buffering
 uuid = { version = "1.6.1", features = ["v4", "fast-rng"] } # Unique IDs
-graphviz-rust = { version = "0.7.0", optional = true } # Drawing graphs
+graphviz-rust = { version = "0.6.6", optional = true } # Drawing graphs
 paste = { version = "1.0.14", optional = true } # Concat identifiers
 
 [build-dependencies]
 quote = { version = "1.0.33", optional = true }
-syn = { version = "2.0.41", features = ["full", "fold"], optional = true }
+syn = { version = "2.0.39", features = ["full", "fold"], optional = true }
 proc-macro2 = { version = "1.0.70", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Reverts ncsurobotics/SW8S-Rust#76

I just realized CI isn’t part of the auto-merge rules….

CC @Bennett-Petzold 