### PR TITLE
Add Macro for Action Chaining

### DIFF
--- a/src/comms/meb/response.rs
+++ b/src/comms/meb/response.rs
@@ -1,8 +1,6 @@
-use std::{
-    sync::{
-        mpsc::{channel, Sender, TryRecvError},
-        Arc,
-    },
+use std::sync::{
+    mpsc::{channel, Sender, TryRecvError},
+    Arc,
 };
 
 use crate::{
@@ -159,20 +157,22 @@ impl Statuses {
         }).await;
     }
 
-    async fn arm_debounce(tarm_count: &Arc<Mutex<Vec<bool>>>, current_tarm: Option<bool>) -> Option<bool> {
-            let mut locked_tarm_count = tarm_count.lock().await;
+    async fn arm_debounce(
+        tarm_count: &Arc<Mutex<Vec<bool>>>,
+        current_tarm: Option<bool>,
+    ) -> Option<bool> {
+        let mut locked_tarm_count = tarm_count.lock().await;
 
-            locked_tarm_count.push(current_tarm.unwrap_or(false));
-            locked_tarm_count.remove(0);
+        locked_tarm_count.push(current_tarm.unwrap_or(false));
+        locked_tarm_count.remove(0);
 
-            if locked_tarm_count.iter().all_equal() {
-                Some(*locked_tarm_count.first().unwrap())
-            } else {
-                None
-            }
+        if locked_tarm_count.iter().all_equal() {
+            Some(*locked_tarm_count.first().unwrap())
+        } else {
+            None
+        }
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct ConfigFile {
     pub control_board_path: String,
     pub meb_path: String,
     pub front_cam: String,
-    pub bottom_cam: String
+    pub bottom_cam: String,
 }
 
 impl Default for ConfigFile {
@@ -20,7 +20,7 @@ impl Default for ConfigFile {
             control_board_path: "/dev/ttyACM0".to_string(),
             meb_path: "/dev/ttyACM2".to_string(),
             front_cam: "/dev/video1".to_string(),
-            bottom_cam: "/dev/video0".to_string()
+            bottom_cam: "/dev/video0".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,12 @@ static FRONT_CAM_CELL: OnceCell<Camera> = OnceCell::const_new();
 async fn front_cam() -> &'static Camera {
     FRONT_CAM_CELL
         .get_or_init(|| async {
-            Camera::jetson_new(&Configuration::default().front_cam, "front", Path::new("/tmp/front_feed.mp4")).unwrap()
+            Camera::jetson_new(
+                &Configuration::default().front_cam,
+                "front",
+                Path::new("/tmp/front_feed.mp4"),
+            )
+            .unwrap()
         })
         .await
 }
@@ -60,7 +65,12 @@ static BOTTOM_CAM_CELL: OnceCell<Camera> = OnceCell::const_new();
 async fn bottom_cam() -> &'static Camera {
     BOTTOM_CAM_CELL
         .get_or_init(|| async {
-            Camera::jetson_new(&Configuration::default().bottom_cam, "bottom", Path::new("/tmp/bottom_feed.mp4")).unwrap()
+            Camera::jetson_new(
+                &Configuration::default().bottom_cam,
+                "bottom",
+                Path::new("/tmp/bottom_feed.mp4"),
+            )
+            .unwrap()
         })
         .await
 }
@@ -176,7 +186,7 @@ async fn run_mission(mission: &str) -> Result<()> {
                 control_board().await,
                 meb().await,
                 front_cam().await,
-                bottom_cam().await
+                bottom_cam().await,
             ))
             .execute()
             .await;
@@ -188,7 +198,7 @@ async fn run_mission(mission: &str) -> Result<()> {
                 control_board().await,
                 meb().await,
                 front_cam().await,
-                bottom_cam().await
+                bottom_cam().await,
             ))
             .execute()
             .await;
@@ -199,7 +209,7 @@ async fn run_mission(mission: &str) -> Result<()> {
                 control_board().await,
                 meb().await,
                 front_cam().await,
-                bottom_cam().await
+                bottom_cam().await,
             ))
             .execute()
             .await;

--- a/src/missions/action.rs
+++ b/src/missions/action.rs
@@ -16,7 +16,7 @@ use super::graph::{stripped_type, DotString};
  */
 pub trait Action {
     /// Represent this node in dot (graphviz) notation
-    fn dot_string(&self) -> DotString {
+    fn dot_string(&self, _parent: &str) -> DotString {
         let id = Uuid::new_v4();
         DotString {
             head_ids: vec![id],
@@ -76,10 +76,10 @@ pub struct ActionConditional<V: Action, W: Action, X: Action> {
 }
 
 impl<V: Action, W: Action, X: Action> Action for ActionConditional<V, W, X> {
-    fn dot_string(&self) -> DotString {
-        let true_str = self.true_branch.dot_string();
-        let false_str = self.false_branch.dot_string();
-        let condition_str = self.condition.dot_string();
+    fn dot_string(&self, _parent: &str) -> DotString {
+        let true_str = self.true_branch.dot_string(stripped_type::<Self>());
+        let false_str = self.false_branch.dot_string(stripped_type::<Self>());
+        let condition_str = self.condition.dot_string(stripped_type::<Self>());
 
         let mut combined_str = true_str.body + &false_str.body + &condition_str.body;
         for tail_id in condition_str.tail_ids {
@@ -152,31 +152,46 @@ pub struct RaceAction<T: Action, U: Action> {
 }
 
 impl<T: Action, U: Action> Action for RaceAction<T, U> {
-    fn dot_string(&self) -> DotString {
-        let first_str = self.first.dot_string();
-        let second_str = self.second.dot_string();
-        let race_id = Uuid::new_v4();
+    fn dot_string(&self, parent: &str) -> DotString {
+        let first_str = self.first.dot_string(stripped_type::<Self>());
+        let second_str = self.second.dot_string(stripped_type::<Self>());
 
-        let mut body_str = format!(
+        if parent == stripped_type::<Self>() {
+            DotString {
+                head_ids: [first_str.head_ids, second_str.head_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                tail_ids: [first_str.tail_ids, second_str.tail_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                body: first_str.body + &second_str.body,
+            }
+        } else {
+            let race_id = Uuid::new_v4();
+
+            let mut body_str = format!(
             "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = red;\n\"{}\" [label = \"Race\", shape = box, fontcolor = red, style = dashed];\n",
             Uuid::new_v4(),
             race_id
         ) + &first_str.body
             + &second_str.body;
 
-        vec![first_str.head_ids, second_str.head_ids]
-            .into_iter()
-            .flatten()
-            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", race_id, id)));
-        body_str.push_str("}\n");
-
-        DotString {
-            head_ids: vec![race_id],
-            tail_ids: vec![first_str.tail_ids, second_str.tail_ids]
+            vec![first_str.head_ids, second_str.head_ids]
                 .into_iter()
                 .flatten()
-                .collect(),
-            body: body_str,
+                .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", race_id, id)));
+            body_str.push_str("}\n");
+
+            DotString {
+                head_ids: vec![race_id],
+                tail_ids: vec![first_str.tail_ids, second_str.tail_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                body: body_str,
+            }
         }
     }
 }
@@ -216,12 +231,25 @@ pub struct DualAction<T: Action, U: Action> {
 }
 
 impl<T: Action, U: Action> Action for DualAction<T, U> {
-    fn dot_string(&self) -> DotString {
-        let first_str = self.first.dot_string();
-        let second_str = self.second.dot_string();
+    fn dot_string(&self, parent: &str) -> DotString {
+        let first_str = self.first.dot_string(stripped_type::<Self>());
+        let second_str = self.second.dot_string(stripped_type::<Self>());
         let (dual_head, dual_tail) = (Uuid::new_v4(), Uuid::new_v4());
 
-        let mut body_str = format!(
+        if parent == stripped_type::<Self>() {
+            DotString {
+                head_ids: [first_str.head_ids, second_str.head_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                tail_ids: [first_str.tail_ids, second_str.tail_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                body: first_str.body + &second_str.body,
+            }
+        } else {
+            let mut body_str = format!(
             "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = blue;\n\"{}\" [label = \"Dual\", shape = box, fontcolor = blue, style = dashed];\n",
             Uuid::new_v4(),
             dual_head
@@ -229,20 +257,21 @@ impl<T: Action, U: Action> Action for DualAction<T, U> {
             &first_str.body
             + &second_str.body;
 
-        vec![first_str.head_ids, second_str.head_ids]
-            .into_iter()
-            .flatten()
-            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", dual_head, id)));
-        vec![first_str.tail_ids, second_str.tail_ids]
-            .into_iter()
-            .flatten()
-            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", id, dual_tail)));
-        body_str.push_str("}\n");
+            vec![first_str.head_ids, second_str.head_ids]
+                .into_iter()
+                .flatten()
+                .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", dual_head, id)));
+            vec![first_str.tail_ids, second_str.tail_ids]
+                .into_iter()
+                .flatten()
+                .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", id, dual_tail)));
+            body_str.push_str("}\n");
 
-        DotString {
-            head_ids: vec![dual_head],
-            tail_ids: vec![dual_tail],
-            body: body_str,
+            DotString {
+                head_ids: vec![dual_head],
+                tail_ids: vec![dual_tail],
+                body: body_str,
+            }
         }
     }
 }
@@ -276,9 +305,9 @@ pub struct ActionChain<V: Action, W: Action> {
 }
 
 impl<V: Action, W: Action> Action for ActionChain<V, W> {
-    fn dot_string(&self) -> DotString {
-        let first_str = self.first.dot_string();
-        let second_str = self.second.dot_string();
+    fn dot_string(&self, _parent: &str) -> DotString {
+        let first_str = self.first.dot_string(stripped_type::<Self>());
+        let second_str = self.second.dot_string(stripped_type::<Self>());
 
         let mut body_str = first_str.body + &second_str.body;
         for tail in &first_str.tail_ids {
@@ -326,9 +355,9 @@ pub struct ActionSequence<V, W> {
 }
 
 impl<V: Action, W: Action> Action for ActionSequence<V, W> {
-    fn dot_string(&self) -> DotString {
-        let first_str = self.first.dot_string();
-        let second_str = self.second.dot_string();
+    fn dot_string(&self, _parent: &str) -> DotString {
+        let first_str = self.first.dot_string(stripped_type::<Self>());
+        let second_str = self.second.dot_string(stripped_type::<Self>());
 
         let mut body_str = first_str.body + &second_str.body;
         for tail in &first_str.tail_ids {
@@ -367,12 +396,31 @@ pub struct ActionParallel<V: Action, W: Action> {
 }
 
 impl<V: Action, W: Action> Action for ActionParallel<V, W> {
-    fn dot_string(&self) -> DotString {
-        let first_str = self.first.blocking_lock().dot_string();
-        let second_str = self.second.blocking_lock().dot_string();
+    fn dot_string(&self, parent: &str) -> DotString {
+        let first_str = self
+            .first
+            .blocking_lock()
+            .dot_string(stripped_type::<Self>());
+        let second_str = self
+            .second
+            .blocking_lock()
+            .dot_string(stripped_type::<Self>());
         let (par_head, par_tail) = (Uuid::new_v4(), Uuid::new_v4());
 
-        let mut body_str = format!(
+        if parent == stripped_type::<Self>() {
+            DotString {
+                head_ids: [first_str.head_ids, second_str.head_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                tail_ids: [first_str.tail_ids, second_str.tail_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                body: first_str.body + &second_str.body,
+            }
+        } else {
+            let mut body_str = format!(
             "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = blue;\n\"{}\" [label = \"Parallel\", shape = box, fontcolor = blue, style = dashed];\n",
             Uuid::new_v4(),
             par_head
@@ -380,20 +428,21 @@ impl<V: Action, W: Action> Action for ActionParallel<V, W> {
             &first_str.body
             + &second_str.body;
 
-        vec![first_str.head_ids, second_str.head_ids]
-            .into_iter()
-            .flatten()
-            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", par_head, id)));
-        vec![first_str.tail_ids, second_str.tail_ids]
-            .into_iter()
-            .flatten()
-            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", id, par_tail)));
-        body_str.push_str("}\n");
+            vec![first_str.head_ids, second_str.head_ids]
+                .into_iter()
+                .flatten()
+                .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", par_head, id)));
+            vec![first_str.tail_ids, second_str.tail_ids]
+                .into_iter()
+                .flatten()
+                .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", id, par_tail)));
+            body_str.push_str("}\n");
 
-        DotString {
-            head_ids: vec![par_head],
-            tail_ids: vec![par_tail],
-            body: body_str,
+            DotString {
+                head_ids: vec![par_head],
+                tail_ids: vec![par_tail],
+                body: body_str,
+            }
         }
     }
 }
@@ -440,12 +489,25 @@ pub struct ActionConcurrent<V: Action, W: Action> {
 }
 
 impl<V: Action, W: Action> Action for ActionConcurrent<V, W> {
-    fn dot_string(&self) -> DotString {
-        let first_str = self.first.dot_string();
-        let second_str = self.second.dot_string();
+    fn dot_string(&self, parent: &str) -> DotString {
+        let first_str = self.first.dot_string(stripped_type::<Self>());
+        let second_str = self.second.dot_string(stripped_type::<Self>());
         let (concurrent_head, concurrent_tail) = (Uuid::new_v4(), Uuid::new_v4());
 
-        let mut body_str = format!(
+        if parent == stripped_type::<Self>() {
+            DotString {
+                head_ids: [first_str.head_ids, second_str.head_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                tail_ids: [first_str.tail_ids, second_str.tail_ids]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                body: first_str.body + &second_str.body,
+            }
+        } else {
+            let mut body_str = format!(
             "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = blue;\n\"{}\" [label = \"Concurrent\", shape = box, fontcolor = blue, style = dashed];\n",
             Uuid::new_v4(),
             concurrent_head
@@ -453,20 +515,25 @@ impl<V: Action, W: Action> Action for ActionConcurrent<V, W> {
             &first_str.body
             + &second_str.body;
 
-        vec![first_str.head_ids, second_str.head_ids]
-            .into_iter()
-            .flatten()
-            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", concurrent_head, id)));
-        vec![first_str.tail_ids, second_str.tail_ids]
-            .into_iter()
-            .flatten()
-            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", id, concurrent_tail)));
-        body_str.push_str("}\n");
+            vec![first_str.head_ids, second_str.head_ids]
+                .into_iter()
+                .flatten()
+                .for_each(|id| {
+                    body_str.push_str(&format!("\"{}\" -> \"{}\";\n", concurrent_head, id))
+                });
+            vec![first_str.tail_ids, second_str.tail_ids]
+                .into_iter()
+                .flatten()
+                .for_each(|id| {
+                    body_str.push_str(&format!("\"{}\" -> \"{}\";\n", id, concurrent_tail))
+                });
+            body_str.push_str("}\n");
 
-        DotString {
-            head_ids: vec![concurrent_head],
-            tail_ids: vec![concurrent_tail],
-            body: body_str,
+            DotString {
+                head_ids: vec![concurrent_head],
+                tail_ids: vec![concurrent_tail],
+                body: body_str,
+            }
         }
     }
 }
@@ -497,8 +564,8 @@ pub struct ActionUntil<T: Action> {
 }
 
 impl<T: Action> Action for ActionUntil<T> {
-    fn dot_string(&self) -> DotString {
-        let action_str = self.action.dot_string();
+    fn dot_string(&self, _parent: &str) -> DotString {
+        let action_str = self.action.dot_string(stripped_type::<Self>());
 
         let mut body_str = action_str.body;
         for head in &action_str.head_ids {
@@ -548,8 +615,8 @@ pub struct ActionWhile<T: Action> {
 }
 
 impl<T: Action> Action for ActionWhile<T> {
-    fn dot_string(&self) -> DotString {
-        let action_str = self.action.dot_string();
+    fn dot_string(&self, _parent: &str) -> DotString {
+        let action_str = self.action.dot_string(stripped_type::<Self>());
 
         let mut body_str = action_str.body;
         for head in &action_str.head_ids {

--- a/src/missions/action.rs
+++ b/src/missions/action.rs
@@ -170,26 +170,29 @@ impl<T: Action, U: Action> Action for RaceAction<T, U> {
             }
         } else {
             let race_id = Uuid::new_v4();
+            let resolve_id = Uuid::new_v4();
 
             let mut body_str = format!(
-            "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = red;\n\"{}\" [label = \"Race\", shape = box, fontcolor = red, style = dashed];\n",
+            "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = red;\n\"{}\" [label = \"Race\", shape = box, fontcolor = red, style = dashed];\nstyle = dashed;\ncolor = red;\n\"{}\" [label = \"Resolve\", shape = box, fontcolor = red, style = dashed];\n",
             Uuid::new_v4(),
-            race_id
+            race_id,
+            resolve_id
         ) + &first_str.body
             + &second_str.body;
 
-            vec![first_str.head_ids, second_str.head_ids]
+            [&first_str.head_ids, &second_str.head_ids]
                 .into_iter()
                 .flatten()
                 .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", race_id, id)));
+            [&first_str.tail_ids, &second_str.tail_ids]
+                .into_iter()
+                .flatten()
+                .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", id, resolve_id)));
             body_str.push_str("}\n");
 
             DotString {
                 head_ids: vec![race_id],
-                tail_ids: vec![first_str.tail_ids, second_str.tail_ids]
-                    .into_iter()
-                    .flatten()
-                    .collect(),
+                tail_ids: vec![resolve_id],
                 body: body_str,
             }
         }

--- a/src/missions/action.rs
+++ b/src/missions/action.rs
@@ -172,6 +172,54 @@ impl<T: Action, U: Action> RaceAction<T, U> {
 }
 
 /**
+ * Action that runs an array actions at the same time and exits both when any exit
+ */
+pub struct ArrRaceAction {
+    actions: Vec<Box<dyn Action>>,
+}
+
+impl Action for ArrRaceAction {
+    fn dot_string(&self) -> DotString {
+        let actions: Vec<_> = self.actions.iter().map(|act| act.dot_string()).collect();
+        let race_id = Uuid::new_v4();
+
+        let mut body_str = format!(
+            "subgraph \"cluster_{}\" {{\nstyle = dashed;\ncolor = red;\n\"{}\" [label = \"Race\", shape = box, fontcolor = red, style = dashed];\n",
+            Uuid::new_v4(),
+            race_id
+        );
+        let add_to_body: String = actions.iter().map(|act| act.body.to_string()).collect();
+        body_str.push_str(&add_to_body);
+
+        actions
+            .clone()
+            .into_iter()
+            .flat_map(|act| act.head_ids)
+            .for_each(|id| body_str.push_str(&format!("\"{}\" -> \"{}\";\n", race_id, id)));
+        body_str.push_str("}\n");
+
+        DotString {
+            head_ids: vec![race_id],
+            tail_ids: actions
+                .clone()
+                .into_iter()
+                .flat_map(|act| act.tail_ids)
+                .collect(),
+            body: body_str,
+        }
+    }
+}
+
+/**
+ * Construct race action
+ */
+impl ArrRaceAction {
+    pub const fn new(actions: Vec<Box<dyn Action>>) -> Self {
+        Self { actions }
+    }
+}
+
+/**
  * Implement race logic where both actions are scheduled until one finishes.  
  */
 #[async_trait]

--- a/src/missions/action_context.rs
+++ b/src/missions/action_context.rs
@@ -1,12 +1,10 @@
-use core::fmt::Debug;
 use async_trait::async_trait;
+use core::fmt::Debug;
 use opencv::core::Mat;
 use tokio::io::{AsyncWriteExt, WriteHalf};
 use tokio_serial::SerialStream;
 
-use crate::{
-    comms::{control_board::ControlBoard, meb::MainElectronicsBoard},
-};
+use crate::comms::{control_board::ControlBoard, meb::MainElectronicsBoard};
 use crate::video_source::appsink::Camera;
 use crate::video_source::MatSource;
 
@@ -28,7 +26,7 @@ pub trait GetMainElectronicsBoard: Send + Sync {
  * Inherit this trait if you have a front camera
  */
 #[async_trait]
-pub trait GetFrontCamMat: {
+pub trait GetFrontCamMat {
     async fn get_front_camera_mat(&self) -> Mat;
 }
 
@@ -36,7 +34,7 @@ pub trait GetFrontCamMat: {
  * Inherit this trait if you have a bottom camera
  */
 #[async_trait]
-pub trait GetBottomCamMat: {
+pub trait GetBottomCamMat {
     async fn get_bottom_camera_mat(&self) -> Mat;
 }
 
@@ -66,8 +64,7 @@ impl<'a, T: AsyncWriteExt + Unpin + Send> FullActionContext<'a, T> {
     }
 }
 
-impl GetControlBoard<WriteHalf<SerialStream>> for FullActionContext<'_, WriteHalf<SerialStream>>
-{
+impl GetControlBoard<WriteHalf<SerialStream>> for FullActionContext<'_, WriteHalf<SerialStream>> {
     fn get_control_board(&self) -> &ControlBoard<WriteHalf<SerialStream>> {
         self.control_board
     }
@@ -81,10 +78,14 @@ impl GetMainElectronicsBoard for FullActionContext<'_, WriteHalf<SerialStream>> 
 
 #[async_trait]
 impl<T: AsyncWriteExt + Unpin + Send> GetFrontCamMat for FullActionContext<'_, T> {
-    async fn get_front_camera_mat(&self) -> Mat { self.front_cam.get_mat().await }
+    async fn get_front_camera_mat(&self) -> Mat {
+        self.front_cam.get_mat().await
+    }
 }
 
 #[async_trait]
 impl<T: AsyncWriteExt + Unpin + Send> GetBottomCamMat for FullActionContext<'_, T> {
-    async fn get_bottom_camera_mat(&self) -> Mat { self.bottom_cam.get_mat().await }
+    async fn get_bottom_camera_mat(&self) -> Mat {
+        self.bottom_cam.get_mat().await
+    }
 }

--- a/src/missions/basic.rs
+++ b/src/missions/basic.rs
@@ -1,7 +1,4 @@
-use crate::{
-    video_source::MatSource,
-    vision::{gate_poles::GatePoles, nn_cv2::OnnxModel},
-};
+use crate::vision::{gate_poles::GatePoles, nn_cv2::OnnxModel};
 
 use super::{
     action::{Action, ActionChain, ActionConcurrent, ActionExec, ActionSequence, ActionWhile},
@@ -14,13 +11,13 @@ use super::{
     movement::{AdjustMovement, Descend},
     vision::VisionNormOffset,
 };
+use crate::missions::action_context::GetFrontCamMat;
 use async_trait::async_trait;
 use tokio::{
     io::WriteHalf,
     time::{sleep, Duration},
 };
 use tokio_serial::SerialStream;
-use crate::missions::action_context::GetFrontCamMat;
 
 #[derive(Debug)]
 pub struct DelayAction {
@@ -79,7 +76,11 @@ pub fn descend_and_go_forward<
 }
 
 pub fn gate_run<
-    Con: Send + Sync + GetControlBoard<WriteHalf<SerialStream>> + GetMainElectronicsBoard + GetFrontCamMat,
+    Con: Send
+        + Sync
+        + GetControlBoard<WriteHalf<SerialStream>>
+        + GetMainElectronicsBoard
+        + GetFrontCamMat,
 >(
     context: &Con,
 ) -> impl ActionExec + '_ {

--- a/src/missions/example.rs
+++ b/src/missions/example.rs
@@ -3,6 +3,8 @@ use async_trait::async_trait;
 use tokio::io::WriteHalf;
 use tokio_serial::SerialStream;
 
+use crate::act_nest;
+
 use super::{
     action::{Action, ActionConcurrent, ActionConditional, ActionExec, ActionSequence, RaceAction},
     action_context::{GetControlBoard, GetMainElectronicsBoard},
@@ -54,6 +56,22 @@ pub fn race_conditional<T: Send + Sync>(context: &T) -> impl Action + '_ {
         AlwaysTrue::new(),
         WaitArm::new(context),
         RaceAction::new(Descend::new(context, -0.5), DelayAction::new(1.0)),
+    )
+}
+
+/// Function to demonstrate use of act_nest
+pub fn race_many<
+    Con: Send + Sync + GetMainElectronicsBoard + GetControlBoard<WriteHalf<SerialStream>>,
+>(
+    _context: &Con,
+) -> impl ActionExec + '_ {
+    act_nest!(
+        RaceAction::new,
+        AlwaysTrue::new(),
+        AlwaysTrue::new(),
+        AlwaysTrue::new(),
+        AlwaysTrue::new(),
+        AlwaysTrue::new()
     )
 }
 

--- a/src/missions/example.rs
+++ b/src/missions/example.rs
@@ -65,13 +65,16 @@ pub fn race_many<
 >(
     _context: &Con,
 ) -> impl ActionExec + '_ {
-    act_nest!(
-        RaceAction::new,
+    ActionSequence::new(
+        act_nest!(
+            RaceAction::new,
+            AlwaysTrue::new(),
+            AlwaysTrue::new(),
+            AlwaysTrue::new(),
+            AlwaysTrue::new(),
+            AlwaysTrue::new()
+        ),
         AlwaysTrue::new(),
-        AlwaysTrue::new(),
-        AlwaysTrue::new(),
-        AlwaysTrue::new(),
-        AlwaysTrue::new()
     )
 }
 

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -40,7 +40,7 @@ impl DotString {
 
 pub fn dot_file<T: ?Sized + Action>(act: &T) -> String {
     let header = "digraph G {\nsplines = true;\nnodesep = 1.0;\n".to_string();
-    header + &act.dot_string().body + "}"
+    header + &act.dot_string("").body + "}"
 }
 
 #[cfg(feature = "graphing")]

--- a/src/missions/graph.rs
+++ b/src/missions/graph.rs
@@ -20,7 +20,7 @@ pub fn stripped_type<T: ?Sized>() -> &'static str {
 }
 
 /// Contains information for dot (graphviz) graphing
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DotString {
     pub head_ids: Vec<Uuid>,
     pub tail_ids: Vec<Uuid>,

--- a/src/missions/vision.rs
+++ b/src/missions/vision.rs
@@ -6,13 +6,13 @@ use anyhow::Result;
 use async_trait::async_trait;
 use num_traits::{FromPrimitive, Num};
 
+use crate::missions::action_context::GetFrontCamMat;
 #[cfg(feature = "logging")]
 use opencv::{core::Vector, imgcodecs::imwrite};
 #[cfg(feature = "logging")]
 use std::fs::create_dir_all;
 #[cfg(feature = "logging")]
 use uuid::Uuid;
-use crate::missions::action_context::GetFrontCamMat;
 
 /// Runs a vision routine to obtain object position
 ///
@@ -37,8 +37,11 @@ impl<'a, T, U, V> VisionNormOffset<'a, T, U, V> {
 impl<T, U, V> Action for VisionNormOffset<'_, T, U, V> {}
 
 #[async_trait]
-impl<T: GetFrontCamMat + Send + Sync, V: Num + FromPrimitive + Send + Sync, U: VisualDetector<V> + Send + Sync>
-    ActionExec for VisionNormOffset<'_, T, U, V>
+impl<
+        T: GetFrontCamMat + Send + Sync,
+        V: Num + FromPrimitive + Send + Sync,
+        U: VisualDetector<V> + Send + Sync,
+    > ActionExec for VisionNormOffset<'_, T, U, V>
 where
     U::Position: RelPos<Number = V> + Draw,
 {


### PR DESCRIPTION
Adds the `act_nest!` macro, which allows the tuple macros to be chained for >2 actions without heavily repeated boilerplate.

Example usage:
```Rust
act_nest!(
	RaceAction::new,
	AlwaysTrue::new(),
	AlwaysTrue::new(),
	AlwaysTrue::new(),
	AlwaysTrue::new(),
	AlwaysTrue::new()
)
```