### PR TITLE
Split processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +381,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -372,6 +394,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -386,37 +409,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
+name = "crossbeam"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.1",
- "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -517,6 +563,27 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1079,15 +1146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,7 +1212,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
+ "memoffset",
  "pin-utils",
  "static_assertions",
 ]
@@ -1276,6 +1334,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -1889,10 +1953,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_approx_eq",
+ "async-channel",
  "bytes",
  "cc",
  "chrono",
  "criterion",
+ "crossbeam",
  "derive-getters",
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,10 @@ bytes = "1.6.0" # Byte buffering
 uuid = { version = "1.9.0", features = ["v4", "fast-rng"] } # Unique IDs
 graphviz-rust = { version = "0.9.0", optional = true } # Drawing graphs
 paste = { version = "1.0.15", optional = true } # Concat identifiers
-chrono = "0.4.38"
+chrono = "0.4.38" # Handling times
 reqwest = { version = "0.12.3", optional = true } # Downloading godot sim
+async-channel = "2.3.1" # Blocking -> Async thread message passing
+crossbeam = "0.8.4" # Blocking thread message passing
 
 [build-dependencies]
 quote = { version = "1.0.36", optional = true }
@@ -56,7 +58,7 @@ cc = { version = "1.0.99", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0" # Floating point eq
-criterion = "0.5.1" # Benchmarking
+criterion = { version = "0.5.1", features = ["async_tokio"] } # Benchmarking
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ logging = []
 #unblocked_logging = ["logging"]
 cuda = ["dep:cc"]
 cuda_f16 = ["cuda"]
-quantize_i8 = []
 graphing = ["dep:graphviz-rust", "dep:quote", "dep:syn", "dep:proc-macro2", "dep:paste"]
 networked_testing = []
 

--- a/benches/model_processing.rs
+++ b/benches/model_processing.rs
@@ -1,11 +1,14 @@
-use std::num::NonZeroUsize;
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use opencv::imgcodecs::{imread, IMREAD_COLOR};
 use sw8s_rust_lib::vision::{
-    buoy_model::BuoyModel, gate_poles::GatePoles, nn_cv2::ModelPipelined, MatWrapper,
-    VisualDetector,
+    buoy_model::BuoyModel,
+    gate_poles::GatePoles,
+    nn_cv2::{ModelPipelined, OnnxModel, VisionModel},
+    MatWrapper, VisualDetector,
 };
+use tokio::time::sleep;
 
 const CUDA_ENABLED: &str = if cfg!(feature = "cuda") {
     if cfg!(feature = "cuda_f16") {
@@ -90,5 +93,148 @@ fn buoy_model(c: &mut Criterion) {
     );
 }
 
+fn pipelined(c: &mut Criterion) {
+    const MAX_MODEL_THREADS: usize = 6;
+    const MAX_POST_PROCESSING_THREADS: usize = 2;
+    const NUM_TAKES: usize = 60;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let images = [
+        imread(
+            "tests/vision/resources/gate_images/straight_on_0.png",
+            IMREAD_COLOR,
+        )
+        .unwrap(),
+        imread(
+            "tests/vision/resources/buoy_images/straight_on_0.png",
+            IMREAD_COLOR,
+        )
+        .unwrap(),
+    ];
+
+    let models_gen: [Box<dyn Fn(usize, usize) -> ModelPipelined>; 2] = [
+        Box::new(|model_threads, post_processing_threads| {
+            runtime.block_on(GatePoles::default().into_pipelined(
+                NonZeroUsize::try_from(model_threads).unwrap(),
+                NonZeroUsize::try_from(post_processing_threads).unwrap(),
+            ))
+        }),
+        Box::new(|model_threads, post_processing_threads| {
+            runtime.block_on(BuoyModel::default().into_pipelined(
+                NonZeroUsize::try_from(model_threads).unwrap(),
+                NonZeroUsize::try_from(post_processing_threads).unwrap(),
+            ))
+        }),
+    ];
+
+    let group_names = ["gate_pipeline".to_string(), "buoy_pipeline".to_string()];
+
+    group_names
+        .into_iter()
+        .zip(images)
+        .zip(models_gen)
+        .for_each(|((group_name, image), model_gen)| {
+            let mut group = c.benchmark_group(group_name + " (" + CUDA_ENABLED + ")");
+            group.sample_size(10);
+
+            for model_threads in 1..=MAX_MODEL_THREADS {
+                for post_processing_threads in 1..=MAX_POST_PROCESSING_THREADS {
+                    let model = Arc::new(model_gen(model_threads, post_processing_threads));
+                    let image = MatWrapper(image.clone());
+
+                    // Approximate frame delivery from a 30 FPS camera
+                    let model_clone = model.clone();
+                    let feeder = runtime.spawn(async move {
+                        loop {
+                            model_clone.update_mat(image.clone());
+                            sleep(Duration::from_secs_f64(1.0 / 30.0)).await;
+                        }
+                    });
+
+                    group.bench_function(
+                        BenchmarkId::from_parameter(format!(
+                            "{:?}",
+                            [model_threads, post_processing_threads]
+                        )),
+                        |b| {
+                            b.to_async(&runtime).iter(|| async {
+                                for _ in 0..NUM_TAKES {
+                                    black_box(model.get_single().await);
+                                }
+                            })
+                        },
+                    );
+
+                    feeder.abort();
+                }
+            }
+
+            group.finish();
+        });
+    runtime.shutdown_background();
+}
+
+fn stages(c: &mut Criterion) {
+    let images = [
+        imread(
+            "tests/vision/resources/buoy_images/straight_on_0.png",
+            IMREAD_COLOR,
+        )
+        .unwrap(),
+        imread(
+            "tests/vision/resources/buoy_images/straight_on_0.png",
+            IMREAD_COLOR,
+        )
+        .unwrap(),
+    ];
+    let models = [
+        GatePoles::default().model().clone(),
+        BuoyModel::default().model().clone(),
+    ];
+    let thresholds = [
+        *GatePoles::default().threshold(),
+        *BuoyModel::default().threshold(),
+    ];
+
+    let names = ["Gate", "Buoy"];
+
+    images
+        .into_iter()
+        .zip(models)
+        .zip(names)
+        .zip(thresholds)
+        .for_each(|(((image, mut model), name), threshold)| {
+            c.bench_function(
+                &(name.to_string() + " Forwarding (" + CUDA_ENABLED + ")"),
+                |b| {
+                    b.iter(|| {
+                        black_box(model.forward(&image));
+                    })
+                },
+            );
+
+            let args = model.post_process_args();
+            let forward_output = model.forward(&image);
+
+            c.bench_function(
+                &(name.to_string() + " Post Processing (" + CUDA_ENABLED + ")"),
+                |b| {
+                    b.iter(|| {
+                        black_box(OnnxModel::post_process(
+                            args,
+                            forward_output.clone(),
+                            threshold,
+                        ));
+                    })
+                },
+            );
+        });
+}
+
 criterion_group!(model_processing, gate_pole_model, buoy_model);
-criterion_main!(model_processing);
+criterion_group!(model_processing_throughput, stages, pipelined);
+criterion_main!(model_processing, model_processing_throughput);

--- a/src/vision/buoy_model.rs
+++ b/src/vision/buoy_model.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use derive_getters::Getters;
 use opencv::{core::Size, prelude::Mat};
 
 use crate::load_onnx;
@@ -51,7 +52,7 @@ impl Display for Target {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Getters)]
 pub struct BuoyModel<T: VisionModel> {
     model: T,
     threshold: f64,

--- a/src/vision/buoy_model.rs
+++ b/src/vision/buoy_model.rs
@@ -4,12 +4,12 @@ use opencv::{core::Size, prelude::Mat};
 use crate::load_onnx;
 
 use super::{
-    nn_cv2::{OnnxModel, VisionModel, YoloClass, YoloDetection},
+    nn_cv2::{ModelPipelined, OnnxModel, VisionModel, YoloClass, YoloDetection},
     yolo_model::YoloProcessor,
 };
 
 use core::hash::Hash;
-use std::{error::Error, fmt::Display};
+use std::{error::Error, fmt::Display, num::NonZeroUsize};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Target {
@@ -88,5 +88,24 @@ impl YoloProcessor for BuoyModel<OnnxModel> {
 
     fn model_size(&self) -> Size {
         self.model.size()
+    }
+}
+
+impl BuoyModel<OnnxModel> {
+    /// Convert into [`ModelPipelined`].
+    ///
+    /// See [`ModelPipelined::new`] for arguments.
+    pub async fn into_pipelined(
+        self,
+        model_threads: NonZeroUsize,
+        post_processing_threads: NonZeroUsize,
+    ) -> ModelPipelined {
+        ModelPipelined::new(
+            self.model,
+            model_threads,
+            post_processing_threads,
+            self.threshold,
+        )
+        .await
     }
 }

--- a/src/vision/gate_poles.rs
+++ b/src/vision/gate_poles.rs
@@ -1,11 +1,6 @@
 use anyhow::Result;
 use derive_getters::Getters;
-use opencv::{
-    core::{Scalar, Size, CV_32F, CV_8S},
-    dnn::{blob_from_image, NetTrait},
-    imgcodecs::{imread, IMREAD_COLOR},
-    prelude::Mat,
-};
+use opencv::{core::Size, prelude::Mat};
 
 use crate::load_onnx;
 
@@ -73,41 +68,13 @@ pub struct GatePoles<T: VisionModel> {
 
 impl GatePoles<OnnxModel> {
     pub fn new(model_name: &str, model_size: i32, threshold: f64) -> Result<Self> {
-        let mut model = OnnxModel::from_file(model_name, model_size, 5)?;
-        #[cfg(feature = "quantize_i8")]
-        {
-            let blob = blob_from_image(
-                &imread("model_calib_data/gate_poles.png", IMREAD_COLOR).unwrap(),
-                1.0 / 255.0,
-                model.get_model_size(),
-                Scalar::from(0.0),
-                true,
-                false,
-                CV_32F,
-            )
-            .unwrap();
-            model.get_net().quantize_def(&blob, CV_32F, CV_8S).unwrap();
-        }
+        let model = OnnxModel::from_file(model_name, model_size, 5)?;
 
         Ok(Self { model, threshold })
     }
 
     pub fn load_640(threshold: f64) -> Self {
-        let mut model = load_onnx!("models/gate_new_640.onnx", 640, 5);
-        #[cfg(feature = "quantize_i8")]
-        {
-            let blob = blob_from_image(
-                &imread("model_calib_data/gate_poles.png", IMREAD_COLOR).unwrap(),
-                1.0 / 255.0,
-                model.get_model_size(),
-                Scalar::from(0.0),
-                true,
-                false,
-                CV_32F,
-            )
-            .unwrap();
-            model.get_net().quantize_def(&blob, CV_32F, CV_32F).unwrap();
-        }
+        let model = load_onnx!("models/gate_new_640.onnx", 640, 5);
 
         Self { model, threshold }
     }

--- a/src/vision/gate_poles.rs
+++ b/src/vision/gate_poles.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use derive_getters::Getters;
 use opencv::{
     core::{Scalar, Size, CV_32F, CV_8S},
     dnn::{blob_from_image, NetTrait},
@@ -64,7 +65,7 @@ impl Display for Target {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Getters)]
 pub struct GatePoles<T: VisionModel> {
     model: T,
     threshold: f64,

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -11,7 +11,7 @@ use std::{
     fmt::Debug,
     hash::Hash,
     iter::Sum,
-    ops::{Add, Deref, Div, Mul},
+    ops::{Add, Deref, DerefMut, Div, Mul},
 };
 
 pub mod buoy;
@@ -290,3 +290,32 @@ impl Mul<&Mat> for DrawRect2d {
         }
     }
 }
+
+/// Allows [`Mat`] to be shared across threads for async.
+/// The C pointer is perfectly safe to share between threads, Rust just
+/// defaults to not giving any pointer Send/Sync so we have to use this wrapper
+/// pattern.
+#[derive(Debug)]
+pub struct MatWrapper(pub Mat);
+
+impl Deref for MatWrapper {
+    type Target = Mat;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for MatWrapper {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Mat> for MatWrapper {
+    fn from(value: Mat) -> Self {
+        Self(value)
+    }
+}
+
+unsafe impl Send for MatWrapper {}
+unsafe impl Sync for MatWrapper {}

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -3,7 +3,7 @@ use derive_getters::Getters;
 use itertools::Itertools;
 use num_traits::{zero, FromPrimitive, Num};
 use opencv::{
-    core::{MatTraitConst, Rect2d, Scalar},
+    core::{MatTraitConst, Rect2d, Scalar, Vector},
     imgproc::{self, LINE_8},
     prelude::Mat,
 };
@@ -295,7 +295,7 @@ impl Mul<&Mat> for DrawRect2d {
 /// The C pointer is perfectly safe to share between threads, Rust just
 /// defaults to not giving any pointer Send/Sync so we have to use this wrapper
 /// pattern.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MatWrapper(pub Mat);
 
 impl Deref for MatWrapper {
@@ -319,3 +319,32 @@ impl From<Mat> for MatWrapper {
 
 unsafe impl Send for MatWrapper {}
 unsafe impl Sync for MatWrapper {}
+
+/// Allows [`Vector<Mat>`] to be shared across threads for async.
+/// The C pointer is perfectly safe to share between threads, Rust just
+/// defaults to not giving any pointer Send/Sync so we have to use this wrapper
+/// pattern.
+#[derive(Debug)]
+pub struct VecMatWrapper(pub Vector<Mat>);
+
+impl Deref for VecMatWrapper {
+    type Target = Vector<Mat>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for VecMatWrapper {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Vector<Mat>> for VecMatWrapper {
+    fn from(value: Vector<Mat>) -> Self {
+        Self(value)
+    }
+}
+
+unsafe impl Send for VecMatWrapper {}
+unsafe impl Sync for VecMatWrapper {}

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -295,7 +295,7 @@ impl Mul<&Mat> for DrawRect2d {
 /// The C pointer is perfectly safe to share between threads, Rust just
 /// defaults to not giving any pointer Send/Sync so we have to use this wrapper
 /// pattern.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct MatWrapper(pub Mat);
 
 impl Deref for MatWrapper {
@@ -324,7 +324,7 @@ unsafe impl Sync for MatWrapper {}
 /// The C pointer is perfectly safe to share between threads, Rust just
 /// defaults to not giving any pointer Send/Sync so we have to use this wrapper
 /// pattern.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VecMatWrapper(pub Vector<Mat>);
 
 impl Deref for VecMatWrapper {

--- a/src/vision/nn_cv2.rs
+++ b/src/vision/nn_cv2.rs
@@ -1,17 +1,25 @@
 use anyhow::Result;
 use derive_getters::Getters;
-use futures::StreamExt;
 use opencv::{
     core::{Rect2d, Scalar, Size, VecN, Vector, CV_32F},
     dnn::{blob_from_image, read_net_from_onnx, read_net_from_onnx_buffer, Net},
     prelude::{Mat, MatTraitConst, NetTrait, NetTraitConst},
 };
-use std::{fmt::Debug, sync::Mutex};
+use std::{
+    fmt::Debug,
+    iter,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Condvar, Mutex},
+};
 use std::{hash::Hash, num::NonZeroUsize};
-use tokio::{spawn, sync::mpsc};
+use tokio::task::spawn_blocking;
 
 #[cfg(feature = "cuda_min_max_loc")]
 use opencv::cudaarithm::min_max_loc as cuda_min_max_loc;
+
+use crate::vision::VecMatWrapper;
+
+use super::MatWrapper;
 
 #[derive(Debug, Clone, Getters, PartialEq)]
 pub struct YoloDetection {
@@ -61,17 +69,23 @@ where
 }
 
 pub trait VisionModel: Debug + Sync + Send {
+    type PostProcessArgs;
     type ModelOutput;
 
     /// Forward pass the matrix through the model, skipping post-processing
     fn model_process(&mut self, image: &Mat) -> Self::ModelOutput;
     /// Convert output from a model into detections
-    fn post_process(&self) -> impl Fn(Self::ModelOutput, f64) -> Vec<YoloDetection>;
+    fn post_process_args(&self) -> Self::PostProcessArgs;
+    fn post_process(
+        args: Self::PostProcessArgs,
+        output: Self::ModelOutput,
+        threshold: f64,
+    ) -> Vec<YoloDetection>;
 
     /// Full input -> output processing
     fn detect_yolo_v5(&mut self, image: &Mat, threshold: f64) -> Vec<YoloDetection> {
         let model_output = self.model_process(image);
-        self.post_process()(model_output, threshold)
+        Self::post_process(self.post_process_args(), model_output, threshold)
     }
     fn size(&self) -> Size;
 }
@@ -80,10 +94,33 @@ pub trait VisionModel: Debug + Sync + Send {
 /* --------------- ONNX implementation -------------- */
 /* -------------------------------------------------- */
 
+/// Wrapper to let Rust know Net is Send and Sync.
+///
+/// We know it doesn't rely on thread-local state, but Rust assumes all
+/// pointers are not Send or Sync by default.
+#[derive(Debug, Clone)]
+struct NetWrapper(pub Net);
+
+impl Deref for NetWrapper {
+    type Target = Net;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for NetWrapper {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+unsafe impl Send for NetWrapper {}
+unsafe impl Sync for NetWrapper {}
+
 /// ONNX vision model running via OpenCV
 #[derive(Debug)]
 pub struct OnnxModel {
-    net: Mutex<Net>,
+    net: Mutex<NetWrapper>,
     //out_blob_names: Vec<String>,
     num_objects: usize,
     //output: Vec<usize>,
@@ -132,7 +169,7 @@ impl OnnxModel {
         */
 
         Ok(Self {
-            net: Mutex::new(net),
+            net: Mutex::new(NetWrapper(net)),
             num_objects,
             model_size: Size::new(model_size, model_size),
             factor: Self::size_to_factor(model_size),
@@ -168,7 +205,7 @@ impl OnnxModel {
         */
 
         Ok(Self {
-            net: Mutex::new(net),
+            net: Mutex::new(NetWrapper(net)),
             num_objects,
             model_size: Size::new(model_size, model_size),
             factor: Self::size_to_factor(model_size),
@@ -263,7 +300,12 @@ impl VisionModel for OnnxModel {
         );
 
         #[cfg(not(feature = "cuda"))]
-        let post_processing = Self::process_net(self.num_objects, self.factor, result, threshold);
+        let post_processing = Self::process_net(
+            self.num_objects,
+            self.factor,
+            result.clone().into_iter(),
+            threshold,
+        );
 
         post_processing
     }
@@ -293,27 +335,40 @@ impl VisionModel for OnnxModel {
             .forward(&mut result, &result_names)
             .unwrap();
 
-        result
+        VecMatWrapper(result)
     }
 
-    type ModelOutput = Vector<Mat>;
+    type ModelOutput = VecMatWrapper;
 
-    fn post_process(&self) -> impl Fn(Self::ModelOutput, f64) -> Vec<YoloDetection> {
-        move |result, threshold| {
-            #[cfg(feature = "cuda")]
-            let post_processing = Self::process_net_cuda(
-                self.num_objects,
-                self.factor as f32,
-                &result,
-                threshold as f32,
-            );
+    #[cfg(feature = "cuda")]
+    type PostProcessArgs = (usize, f32);
+    #[cfg(not(feature = "cuda"))]
+    type PostProcessArgs = (usize, f64);
 
-            #[cfg(not(feature = "cuda"))]
-            let post_processing =
-                Self::process_net(self.num_objects, self.factor, result, threshold);
-
-            post_processing
+    fn post_process_args(&self) -> Self::PostProcessArgs {
+        #[cfg(feature = "cuda")]
+        {
+            (self.num_objects, self.factor as f32)
         }
+        #[cfg(not(feature = "cuda"))]
+        {
+            (self.num_objects, self.factor)
+        }
+    }
+
+    fn post_process(
+        args: Self::PostProcessArgs,
+        output: Self::ModelOutput,
+        threshold: f64,
+    ) -> Vec<YoloDetection> {
+        #[cfg(feature = "cuda")]
+        let post_processing = Self::process_net_cuda(args.0, args.1, &output, threshold as f32);
+
+        #[cfg(not(feature = "cuda"))]
+        let post_processing =
+            Self::process_net(args.0, args.1, output.clone().into_iter(), threshold);
+
+        post_processing
     }
 
     fn size(&self) -> Size {
@@ -497,33 +552,165 @@ impl OnnxModel {
     }
 }
 
-/// [`OnnxModel`] that pipelines processing in blocking threads.
+/// Utility struct for [`ModelPipelined`].
+///
+/// * `mat`: latest available matrix. Set to default on read.
+/// * `dropped`: tracks if ModelPipelined is dropped, for thread cleanup.
 #[derive(Debug)]
-struct OnnxModelPipelined<T: VisionModel + Clone> {
-    input_ch: async_channel::Sender<Mat>,
-    output_ch: mpsc::Receiver<T::ModelOutput>,
+struct ModelPipelinedInput {
+    pub mat: MatWrapper,
+    pub dropped: bool,
 }
 
-impl<T: VisionModel + Clone> OnnxModelPipelined<T> {
-    fn new(
+/// [`OnnxModel`] that pipelines processing in blocking threads.
+///
+/// The input is processed on blocking threads, and only the newest available
+/// input should be processed, so `input_mut` is used for threads to claim
+/// whenever an unclaimed new input is available. It also tracks for when to
+/// drop the threads.
+///
+/// The output is asynchronous, written to with blocking synchronous calls from
+/// the post processing stage.
+#[derive(Debug)]
+pub struct ModelPipelined {
+    input_mut: Arc<(Condvar, Mutex<ModelPipelinedInput>)>,
+    output_ch: async_channel::Receiver<Vec<YoloDetection>>,
+}
+
+impl ModelPipelined {
+    /// Pipelines model processing in blocking threads.
+    ///
+    /// # Parameters
+    /// * `model`: A model to be cloned into threads.
+    /// * `model_threads`: Number of threads with processing models.
+    /// * `post_processing_threads`: Number of threads converting model output.
+    /// * `threshold`: [0, 1] minimum score for a detection.
+    pub async fn new<T>(
         model: T,
         model_threads: NonZeroUsize,
         post_processing_threads: NonZeroUsize,
-    ) -> Self {
-        let (input_ch, input_rx) = async_channel::unbounded();
-        let (output_tx, output_ch) = mpsc::unbounded_channel();
-        for 0..model_threads.into() {
-            let model = model.clone();
-            let input_rx = input_rx.clone();
-        spawn(async {
-            while let Some(input) = input_rx.next().await {
-                model.model_process(input);
-            }
-        });
+        threshold: f64,
+    ) -> Self
+    where
+        T: VisionModel + Clone + Send + Sync + 'static,
+        T::ModelOutput: Send,
+        T::PostProcessArgs: Send + Clone,
+    {
+        let input_mut = Arc::new((
+            Condvar::new(),
+            Mutex::new(ModelPipelinedInput {
+                mat: MatWrapper(Mat::default()),
+                dropped: false,
+            }),
+        ));
+        let (output_tx, output_ch) = async_channel::unbounded();
+
+        // Both processing threads are blocking, so using a sync structure.
+        let (inner_tx, inner_rx) = crossbeam::channel::unbounded();
+
+        for _ in 0..model_threads.into() {
+            let mut model = model.clone();
+            let input_mut = input_mut.clone();
+            let inner_tx = inner_tx.clone();
+
+            spawn_blocking(move || loop {
+                let input = {
+                    // When we get a notification on this thread, new data can
+                    // always be directly claimed.
+                    let mut guard = input_mut.1.lock().unwrap();
+                    guard = input_mut.0.wait(guard).unwrap();
+
+                    // Exit this thread if the struct was dropped
+                    if guard.dropped {
+                        break;
+                    };
+
+                    // Move the matrix to local memory to avoid holding up the
+                    // lock. The default value should never be read by another
+                    // thread.
+                    std::mem::take(&mut guard.mat)
+                };
+
+                // Hand off to post processing
+                inner_tx.send(model.model_process(&input)).unwrap();
+            });
+        }
+
+        for _ in 0..post_processing_threads.into() {
+            let inner_rx = inner_rx.clone();
+            let output_tx = output_tx.clone();
+            let post_process_args = model.post_process_args();
+
+            spawn_blocking(move || {
+                // Thread exits when model output threads exit (struct drop).
+                while let Ok(input) = inner_rx.recv() {
+                    let post_process_args = post_process_args.clone();
+                    let processed_output =
+                        T::post_process(post_process_args.clone(), input, threshold);
+                    // Blocking call on this end, async on the other.
+                    // Never stalls for capacity, since output is unbounded.
+                    output_tx.send_blocking(processed_output).unwrap();
+                }
+            });
         }
 
         Self {
-            input_ch, output_ch
+            input_mut,
+            output_ch,
         }
+    }
+
+    /// Update the model with a newer [`Mat`] to process.
+    pub fn update_mat(&self, mat: MatWrapper) -> &Self {
+        let mut input = self.input_mut.1.lock().unwrap();
+        input.mat = mat;
+        self.input_mut.0.notify_one();
+        self
+    }
+
+    /// Get the oldest available output.
+    ///
+    /// Stalls until an output is available.
+    pub async fn get_single(&self) -> Vec<YoloDetection> {
+        self.output_ch.recv().await.unwrap()
+    }
+
+    /// Get the oldest N available outputs.
+    ///
+    /// Stalls until N outputs are available.
+    /// Returns in order oldest -> newest.
+    pub async fn get_multiple(&self, count: usize) -> Vec<Vec<YoloDetection>> {
+        let mut output = Vec::with_capacity(count);
+        for _ in 0..count {
+            output.push(self.output_ch.recv().await.unwrap())
+        }
+        output
+    }
+
+    /// Get the newest N available outputs.
+    ///
+    /// Stalls until N outputs are available.
+    /// Returns in order oldest -> newest.
+    pub async fn get_multiple_newest(&self, count: usize) -> Vec<Vec<YoloDetection>> {
+        let mut output = Vec::with_capacity(count);
+        for _ in 0..count {
+            output.push(self.output_ch.recv().await.unwrap())
+        }
+        output.extend(iter::from_fn(|| self.output_ch.try_recv().ok()));
+
+        output.into_iter().rev().take(count).rev().collect()
+    }
+
+    /// Get all available output immediately.
+    pub async fn get_all(&self) -> Vec<Vec<YoloDetection>> {
+        iter::from_fn(|| self.output_ch.try_recv().ok()).collect()
+    }
+}
+
+impl Drop for ModelPipelined {
+    /// Trigger thread cleanup.
+    fn drop(&mut self) {
+        self.input_mut.1.lock().unwrap().dropped = true;
+        self.input_mut.0.notify_all();
     }
 }

--- a/src/vision/nn_cv2.rs
+++ b/src/vision/nn_cv2.rs
@@ -303,7 +303,7 @@ impl VisionModel for OnnxModel {
         let post_processing = Self::process_net(
             self.num_objects,
             self.factor,
-            result.clone().into_iter(),
+            result.0.into_iter(),
             threshold,
         );
 
@@ -365,8 +365,7 @@ impl VisionModel for OnnxModel {
         let post_processing = Self::process_net_cuda(args.0, args.1, &output, threshold as f32);
 
         #[cfg(not(feature = "cuda"))]
-        let post_processing =
-            Self::process_net(args.0, args.1, output.clone().into_iter(), threshold);
+        let post_processing = Self::process_net(args.0, args.1, output.0.into_iter(), threshold);
 
         post_processing
     }

--- a/src/vision/nn_cv2.rs
+++ b/src/vision/nn_cv2.rs
@@ -300,12 +300,7 @@ impl VisionModel for OnnxModel {
         );
 
         #[cfg(not(feature = "cuda"))]
-        let post_processing = Self::process_net(
-            self.num_objects,
-            self.factor,
-            result.0.into_iter(),
-            threshold,
-        );
+        let post_processing = Self::process_net(self.num_objects, self.factor, result.0, threshold);
 
         post_processing
     }
@@ -365,7 +360,7 @@ impl VisionModel for OnnxModel {
         let post_processing = Self::process_net_cuda(args.0, args.1, &output, threshold as f32);
 
         #[cfg(not(feature = "cuda"))]
-        let post_processing = Self::process_net(args.0, args.1, output.0.into_iter(), threshold);
+        let post_processing = Self::process_net(args.0, args.1, output.0, threshold);
 
         post_processing
     }

--- a/src/vision/path.rs
+++ b/src/vision/path.rs
@@ -17,7 +17,7 @@ use crate::vision::image_prep::{binary_pca, cvt_binary_to_points};
 use super::{
     image_prep::{kmeans, resize},
     pca::PosVector,
-    VisualDetection, VisualDetector,
+    MatWrapper, VisualDetection, VisualDetector,
 };
 
 static FORWARD: (f64, f64) = (0.0, -1.0);
@@ -55,35 +55,6 @@ impl Yuv {
             && self.v <= range.end().v
     }
 }
-
-/// Allows [`Mat`] to be shared across threads for async.
-/// The C pointer is perfectly safe to share between threads, Rust just
-/// defaults to not giving any pointer Send/Sync so we have to use this wrapper
-/// pattern.
-#[derive(Debug)]
-struct MatWrapper(Mat);
-
-impl Deref for MatWrapper {
-    type Target = Mat;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for MatWrapper {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl From<Mat> for MatWrapper {
-    fn from(value: Mat) -> Self {
-        Self(value)
-    }
-}
-
-unsafe impl Send for MatWrapper {}
-unsafe impl Sync for MatWrapper {}
 
 #[derive(Debug)]
 pub struct Path {

--- a/src/vision/path.rs
+++ b/src/vision/path.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs::create_dir_all,
-    ops::{Deref, DerefMut, RangeInclusive},
-};
+use std::{fs::create_dir_all, ops::RangeInclusive};
 
 use itertools::Itertools;
 use opencv::{

--- a/src/vision/path.rs
+++ b/src/vision/path.rs
@@ -65,7 +65,7 @@ pub struct Path {
 
 impl Path {
     pub fn image(&self) -> Mat {
-        self.image.clone()
+        (*self.image).clone()
     }
 }
 


### PR DESCRIPTION
`ModelPipelined` allows for parallel workers processing and post-processing a model. This way threads can be spawned to take advantage of spare compute and memory on whichever part of processing bottlenecks, increasing the throughput at minimal latency cost. Inactive model forwarding threads will always claim the most recent non-redundant data to process.

Other commits are generally in service of this struct. Benchmarks for pipelined execution and each part of execution were added, to prove that inter-thread communication overhead is minor and make on-Jetson tuning measurements feasible.